### PR TITLE
Fix/feeds

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -244,7 +244,7 @@ function AppContent() {
             <Route path="topics" element={<TopicsFeed />}>
               <Route path=":tag" element={<TopicExplorer />} />
             </Route>
-            <Route path="polls" index element={<PollFeed />} />
+            <Route path="polls" element={<PollFeed />} />
             <Route path="follow-packs" element={<FollowPacksFeed />} />
             <Route path="follow-packs/:naddr" element={<FollowPackDetail />} />
             <Route path="articles" element={<ArticlesFeed />} />

--- a/src/components/Feed/ArticlesFeed.tsx
+++ b/src/components/Feed/ArticlesFeed.tsx
@@ -3,6 +3,7 @@ import { Event, Filter } from "nostr-tools";
 import { Box, Typography } from "@mui/material";
 import { useRelays } from "../../hooks/useRelays";
 import { dataLayer } from "@formstr/local-relay";
+import { useRelayRefresh } from "../../dataLayer/hooks";
 import { useUserContext } from "../../hooks/useUserContext";
 import { useSubNav } from "../../contexts/SubNavContext";
 import { useAppContext } from "../../hooks/useAppContext";
@@ -20,6 +21,7 @@ const ArticlesFeed: React.FC = () => {
   const { user } = useUserContext();
   const { fetchUserProfileThrottled, profiles } = useAppContext();
   const { setItems, clearItems } = useSubNav();
+  const relayRefresh = useRelayRefresh();
 
   const savedSource = (localStorage.getItem(STORAGE_KEY) as Source) || "global";
   const [source, setSource] = useState<Source>(savedSource);
@@ -113,7 +115,7 @@ const ArticlesFeed: React.FC = () => {
   useEffect(() => {
     fetchBatch(true);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [source]);
+  }, [source, relayRefresh]);
 
   const handleEndReached = useCallback(() => {
     if (!loadingMore && !loading && initialLoadDone && !exhausted) {

--- a/src/components/Feed/CreateFAB.tsx
+++ b/src/components/Feed/CreateFAB.tsx
@@ -147,6 +147,18 @@ const CreateFAB: React.FC<CreateFABProps> = ({ extraActions = [] }) => {
             onClick={handleRefresh}
             sx={actionSx}
           />
+          {extraActions.map((action, index) => (
+            <SpeedDialAction
+              key={`extra-action-${index}`}
+              icon={action.icon}
+              tooltipTitle={action.name}
+              onClick={() => {
+                setOpen(false);
+                action.onClick();
+              }}
+              sx={actionSx}
+            />
+          ))}
           <SpeedDialAction
             icon={
               <Badge badgeContent={draftCount} color="primary" invisible={draftCount === 0} max={99}>

--- a/src/components/Feed/FollowPacksFeed.tsx
+++ b/src/components/Feed/FollowPacksFeed.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from "react";
 import { Event, Filter } from "nostr-tools";
 import { Box, Button, CircularProgress, Typography } from "@mui/material";
 import { dataLayer } from "@formstr/local-relay";
+import { useRelayRefresh } from "../../dataLayer/hooks";
 import { useUserContext } from "../../hooks/useUserContext";
 import { useListContext } from "../../hooks/useListContext";
 import { useSubNav } from "../../contexts/SubNavContext";
@@ -18,6 +19,7 @@ const FollowPacksFeed: React.FC = () => {
   const { user } = useUserContext();
   const { lists, bookmarkedPackKeys } = useListContext();
   const { setItems, clearItems } = useSubNav();
+  const relayRefresh = useRelayRefresh();
 
   const savedSource = (localStorage.getItem(STORAGE_KEY) as Source) || "global";
   const [source, setSource] = useState<Source>(savedSource);
@@ -131,7 +133,7 @@ const FollowPacksFeed: React.FC = () => {
   useEffect(() => {
     if (source !== "bookmarked") fetchBatch();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [source]);
+  }, [source, relayRefresh]);
 
   const displayPacks = source === "bookmarked" ? bookmarkedPacks : packs;
   const isLoading = source === "bookmarked" ? false : loading;

--- a/src/components/Feed/HomeFeed.tsx
+++ b/src/components/Feed/HomeFeed.tsx
@@ -9,6 +9,7 @@ import { safeSetItem } from "../../utils/localStorage";
 import { useFeedActions } from "../../contexts/FeedActionsContext";
 import { useAppContext } from "../../hooks/useAppContext";
 import { dataLayer } from "@formstr/local-relay";
+import { useRelayRefresh } from "../../dataLayer/hooks";
 import UnifiedFeed from "./UnifiedFeed";
 import { Notes } from "../Notes";
 import PollResponseForm from "../PollResponse/PollResponseForm";
@@ -83,6 +84,7 @@ const HomeFeed: React.FC = () => {
   const { requestReportCheck, requestUserReportCheck } = useReports();
   const { setItems, clearItems } = useSubNav();
   const { registerRefresh } = useFeedActions();
+  const relayRefresh = useRelayRefresh();
 
   const [source, setSource] = useState<Source>(() => {
     const saved = localStorage.getItem(STORAGE_KEY);
@@ -413,7 +415,7 @@ const HomeFeed: React.FC = () => {
     setInitialLoadDone(cached.length > 0);
     fetchBatch("initial");
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [source, relays]);
+  }, [source, relays, relayRefresh]);
 
   // The user's follows / web-of-trust resolve asynchronously after login, so on
   // a cold start the initial fetch above often runs with an empty author set and

--- a/src/components/Feed/MoviesFeed.tsx
+++ b/src/components/Feed/MoviesFeed.tsx
@@ -2,6 +2,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import { Filter } from "nostr-tools";
 import { dataLayer } from "@formstr/local-relay";
+import { useRelayRefresh } from "../../dataLayer/hooks";
 import MovieCard from "../Movies/MovieCard";
 import RateMovieModal from "../Ratings/RateMovieModal";
 import { Card, CardContent, Typography, CircularProgress, Box, Button } from "@mui/material";
@@ -18,6 +19,7 @@ const MoviesFeed: React.FC = () => {
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const loadingRef = useRef(false);
   const cursorRef = useRef<number | undefined>(undefined);
+  const relayRefresh = useRelayRefresh();
 
   // Keep refs in sync
   cursorRef.current = cursor;
@@ -130,7 +132,7 @@ const MoviesFeed: React.FC = () => {
       if (timeoutRef.current) clearTimeout(timeoutRef.current);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [relayRefresh]);
 
   return (
     <Box sx={{ height: "100%", overflowY: "auto" }}>

--- a/src/components/Feed/PollFeed.tsx
+++ b/src/components/Feed/PollFeed.tsx
@@ -14,6 +14,7 @@ import { useSubNav } from "../../contexts/SubNavContext";
 import { useFeedActions } from "../../contexts/FeedActionsContext";
 import { safeSetItem } from "../../utils/localStorage";
 import { useRelayRefresh } from "../../dataLayer/hooks";
+import { isRelayHydrated } from "../../dataLayer/relayRefresh";
 
 // Minimal closer shape the feed tracks. The worker owns relays/chunking, so the
 // app only needs to be able to drop its interest.
@@ -238,6 +239,11 @@ export const PollFeed = () => {
 
     const onComplete = (failed = false) => {
       if (eoseFired) return;
+      // A pre-hydration EOSE means the store was still loading, not actually
+      // empty — wait for the hydration-triggered re-run (relayRefresh dep
+      // below) instead of flashing an empty/failed state. The hard timeout
+      // above still fires `failed` regardless, so this can't hang forever.
+      if (!failed && !isRelayHydrated()) return;
       eoseFired = true;
       clearTimeout(timeoutId);
       if (failed) {

--- a/src/components/Feed/PollFeed.tsx
+++ b/src/components/Feed/PollFeed.tsx
@@ -13,6 +13,7 @@ import OverlappingAvatars from "../Common/OverlappingAvatars";
 import { useSubNav } from "../../contexts/SubNavContext";
 import { useFeedActions } from "../../contexts/FeedActionsContext";
 import { safeSetItem } from "../../utils/localStorage";
+import { useRelayRefresh } from "../../dataLayer/hooks";
 
 // Minimal closer shape the feed tracks. The worker owns relays/chunking, so the
 // app only needs to be able to drop its interest.
@@ -91,6 +92,7 @@ export const PollFeed = () => {
   const [pendingPollEvents, setPendingPollEvents] = useState<Event[]>([]);
   // Ref so handleIncomingEvent can read the current value without a stale closure
   const loadingInitialRef = useRef(true);
+  const relayRefresh = useRelayRefresh();
 
   const { user } = useUserContext();
   const { requestReportCheck, requestUserReportCheck } = useReports();
@@ -385,7 +387,7 @@ export const PollFeed = () => {
     setFeedSubscription(closer);
     return () => closer?.unsubscribe();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [eventSource]);
+  }, [eventSource, relayRefresh]);
 
   useEffect(() => {
     let closer: FeedSub | undefined;

--- a/src/components/Feed/TopicsFeed/TopicsExplorerFeed.tsx
+++ b/src/components/Feed/TopicsFeed/TopicsExplorerFeed.tsx
@@ -26,6 +26,7 @@ import UnifiedFeed from "../UnifiedFeed";
 import OverlappingAvatars from "../../../components/Common/OverlappingAvatars";
 import { signEvent } from "../../../nostr";
 import { dataLayer } from "@formstr/local-relay";
+import { useRelayRefresh } from "../../../dataLayer/hooks";
 import { useMetadata } from "../../../hooks/MetadataProvider";
 import { selectBestMetadataEvent } from "../../../utils/utils";
 import {
@@ -46,6 +47,7 @@ const TopicExplorer: React.FC = () => {
   const { myTopics, addTopicToMyTopics, removeTopicFromMyTopics } =
     useListContext();
   const navigate = useNavigate();
+  const relayRefresh = useRelayRefresh();
 
   const [tabValue, setTabValue] = useState<0 | 1>(0);
   const [feedMode, setFeedMode] = useState<
@@ -348,7 +350,7 @@ const TopicExplorer: React.FC = () => {
         subRef.current.close();
       }
     };
-  }, [tag, relays]);
+  }, [tag, relays, relayRefresh]);
 
   const sortedEvents = useMemo(() => {
     const base = tabValue === 0 ? notesEvents : pollsEvents;

--- a/src/components/Feed/TopicsFeed/index.tsx
+++ b/src/components/Feed/TopicsFeed/index.tsx
@@ -16,6 +16,7 @@ import {
 } from "@mui/material";
 import SearchIcon from "@mui/icons-material/Search";
 import { dataLayer, type ObserveHandle } from "@formstr/local-relay";
+import { useRelayRefresh } from "../../../dataLayer/hooks";
 import { Virtuoso } from "react-virtuoso";
 import TopicCard from "./TopicsCard";
 import { useListContext } from "../../../hooks/useListContext";
@@ -41,6 +42,7 @@ const TopicsFeed: React.FC = () => {
   const interestsRefreshRef = useRef<(() => void) | undefined>(undefined);
 
   const { relays } = useRelays();
+  const relayRefresh = useRelayRefresh();
   const { myTopics } = useListContext();
   const navigate = useNavigate();
   const { tag } = useParams();
@@ -127,7 +129,7 @@ const TopicsFeed: React.FC = () => {
     });
 
     return () => sub.unobserve();
-  }, [relays, tagsMap]);
+  }, [relays, tagsMap, relayRefresh]);
 
   useEffect(() => {
     // If a specific tag is selected or no relays, don't fetch topics
@@ -197,7 +199,7 @@ const TopicsFeed: React.FC = () => {
       subsRef.current.forEach((s) => s.unobserve());
       subsRef.current = [];
     };
-  }, [tag, relays, refreshKey]); // refreshKey forces a re-fetch on manual refresh
+  }, [tag, relays, refreshKey, relayRefresh]); // refreshKey forces a re-fetch on manual refresh
 
   const handleRefresh = useCallback(() => {
     if (activeTab === "interests") {

--- a/src/components/Feed/TopicsFeed/index.tsx
+++ b/src/components/Feed/TopicsFeed/index.tsx
@@ -17,6 +17,7 @@ import {
 import SearchIcon from "@mui/icons-material/Search";
 import { dataLayer, type ObserveHandle } from "@formstr/local-relay";
 import { useRelayRefresh } from "../../../dataLayer/hooks";
+import { isRelayHydrated } from "../../../dataLayer/relayRefresh";
 import { Virtuoso } from "react-virtuoso";
 import TopicCard from "./TopicsCard";
 import { useListContext } from "../../../hooks/useListContext";
@@ -164,7 +165,10 @@ const TopicsFeed: React.FC = () => {
           }
         },
         onEose: () => {
-          if (isMounted.current) setLoading(false);
+          // A pre-hydration EOSE means the store was still loading, not
+          // actually empty — the relayRefresh-dep re-run below retries once
+          // hydration completes, so hold off on clearing the spinner here.
+          if (isMounted.current && isRelayHydrated()) setLoading(false);
         },
       }
     );

--- a/src/components/Profile/UserArticlesFeed.tsx
+++ b/src/components/Profile/UserArticlesFeed.tsx
@@ -3,6 +3,7 @@ import { Event, Filter } from "nostr-tools";
 import { Box, Typography } from "@mui/material";
 import { dataLayer } from "@formstr/local-relay";
 import { useRelayRefresh } from "../../dataLayer/hooks";
+import { isRelayHydrated } from "../../dataLayer/relayRefresh";
 import { useAppContext } from "../../hooks/useAppContext";
 import { ArticleCard } from "../Articles/ArticleCard";
 import UnifiedFeed from "../Feed/UnifiedFeed";
@@ -31,9 +32,19 @@ const UserArticlesFeed: React.FC<UserArticlesFeedProps> = ({ pubkey, scrollConta
           return [...prev, event].sort((a, b) => b.created_at - a.created_at);
         });
       },
-      onEose() { setLoading(false); },
+      onEose() {
+        // A pre-hydration EOSE means the store was still loading, not
+        // actually empty — the relayRefresh-dep re-run below retries once
+        // hydration completes, so hold off on clearing the spinner here.
+        if (isRelayHydrated()) setLoading(false);
+      },
     });
-    return () => handle.unobserve();
+    // Safety net: don't let a stuck hydration signal spin forever.
+    const timeout = setTimeout(() => setLoading(false), 8000);
+    return () => {
+      handle.unobserve();
+      clearTimeout(timeout);
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pubkey, relayRefresh]);
 

--- a/src/components/Profile/UserArticlesFeed.tsx
+++ b/src/components/Profile/UserArticlesFeed.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useState } from "react";
 import { Event, Filter } from "nostr-tools";
 import { Box, Typography } from "@mui/material";
 import { dataLayer } from "@formstr/local-relay";
+import { useRelayRefresh } from "../../dataLayer/hooks";
 import { useAppContext } from "../../hooks/useAppContext";
 import { ArticleCard } from "../Articles/ArticleCard";
 import UnifiedFeed from "../Feed/UnifiedFeed";
@@ -16,6 +17,7 @@ const UserArticlesFeed: React.FC<UserArticlesFeedProps> = ({ pubkey, scrollConta
   const [articles, setArticles] = useState<Event[]>([]);
   const [loading, setLoading] = useState(true);
   const { fetchUserProfileThrottled, profiles } = useAppContext();
+  const relayRefresh = useRelayRefresh();
 
   const fetchArticles = useCallback(() => {
     if (!pubkey) return;
@@ -33,7 +35,7 @@ const UserArticlesFeed: React.FC<UserArticlesFeedProps> = ({ pubkey, scrollConta
     });
     return () => handle.unobserve();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pubkey]);
+  }, [pubkey, relayRefresh]);
 
   useEffect(() => {
     const cleanup = fetchArticles();

--- a/src/components/Profile/UserNotesFeed.tsx
+++ b/src/components/Profile/UserNotesFeed.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState, useCallback, useMemo } from "react";
 import { Event, Filter } from "nostr-tools";
 import { Box, Typography, Tabs, Tab } from "@mui/material";
 import { dataLayer } from "@formstr/local-relay";
+import { useRelayRefresh } from "../../dataLayer/hooks";
 import { Notes } from "../Notes";
 import UnifiedFeed from "../Feed/UnifiedFeed";
 
@@ -23,6 +24,7 @@ const UserNotesFeed: React.FC<UserNotesFeedProps> = ({ pubkey, scrollContainerRe
   const [notes, setNotes] = useState<Event[]>([]);
   const [loading, setLoading] = useState(true);
   const [subTab, setSubTab] = useState(0);
+  const relayRefresh = useRelayRefresh();
 
   const fetchNotes = useCallback(() => {
     if (!pubkey) return;
@@ -50,7 +52,7 @@ const UserNotesFeed: React.FC<UserNotesFeedProps> = ({ pubkey, scrollContainerRe
     });
 
     return () => handle.unobserve();
-  }, [pubkey]);
+  }, [pubkey, relayRefresh]);
 
   useEffect(() => {
     const cleanup = fetchNotes();

--- a/src/components/Profile/UserNotesFeed.tsx
+++ b/src/components/Profile/UserNotesFeed.tsx
@@ -3,6 +3,7 @@ import { Event, Filter } from "nostr-tools";
 import { Box, Typography, Tabs, Tab } from "@mui/material";
 import { dataLayer } from "@formstr/local-relay";
 import { useRelayRefresh } from "../../dataLayer/hooks";
+import { isRelayHydrated } from "../../dataLayer/relayRefresh";
 import { Notes } from "../Notes";
 import UnifiedFeed from "../Feed/UnifiedFeed";
 
@@ -47,11 +48,19 @@ const UserNotesFeed: React.FC<UserNotesFeedProps> = ({ pubkey, scrollContainerRe
         });
       },
       onEose() {
-        setLoading(false);
+        // A pre-hydration EOSE means the store was still loading, not
+        // actually empty — the relayRefresh-dep re-run below retries once
+        // hydration completes, so hold off on clearing the spinner here.
+        if (isRelayHydrated()) setLoading(false);
       },
     });
 
-    return () => handle.unobserve();
+    // Safety net: don't let a stuck hydration signal spin forever.
+    const timeout = setTimeout(() => setLoading(false), 8000);
+    return () => {
+      handle.unobserve();
+      clearTimeout(timeout);
+    };
   }, [pubkey, relayRefresh]);
 
   useEffect(() => {

--- a/src/components/Profile/UserNotesFeed.tsx
+++ b/src/components/Profile/UserNotesFeed.tsx
@@ -61,6 +61,9 @@ const UserNotesFeed: React.FC<UserNotesFeedProps> = ({ pubkey, scrollContainerRe
       handle.unobserve();
       clearTimeout(timeout);
     };
+    // relayRefresh isn't read in the body — it's a dependency purely to force
+    // a fresh fetchNotes identity (and re-run below) once hydration completes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pubkey, relayRefresh]);
 
   useEffect(() => {

--- a/src/components/Profile/UserPollsFeed.tsx
+++ b/src/components/Profile/UserPollsFeed.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState, useCallback } from "react";
 import { Event, Filter } from "nostr-tools";
 import { Box, Typography } from "@mui/material";
 import { dataLayer } from "@formstr/local-relay";
+import { useRelayRefresh } from "../../dataLayer/hooks";
 import PollResponseForm from "../PollResponse/PollResponseForm";
 import UnifiedFeed from "../Feed/UnifiedFeed";
 
@@ -16,6 +17,7 @@ const KIND_POLL = 1068;
 const UserPollsFeed: React.FC<UserPollsFeedProps> = ({ pubkey, scrollContainerRef }) => {
   const [polls, setPolls] = useState<Event[]>([]);
   const [loading, setLoading] = useState(true);
+  const relayRefresh = useRelayRefresh();
 
   const fetchPolls = useCallback(() => {
     if (!pubkey) return;
@@ -43,7 +45,7 @@ const UserPollsFeed: React.FC<UserPollsFeedProps> = ({ pubkey, scrollContainerRe
     });
 
     return () => handle.unobserve();
-  }, [pubkey]);
+  }, [pubkey, relayRefresh]);
 
   useEffect(() => {
     const cleanup = fetchPolls();

--- a/src/components/Profile/UserPollsFeed.tsx
+++ b/src/components/Profile/UserPollsFeed.tsx
@@ -54,6 +54,9 @@ const UserPollsFeed: React.FC<UserPollsFeedProps> = ({ pubkey, scrollContainerRe
       handle.unobserve();
       clearTimeout(timeout);
     };
+    // relayRefresh isn't read in the body — it's a dependency purely to force
+    // a fresh fetchPolls identity (and re-run below) once hydration completes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pubkey, relayRefresh]);
 
   useEffect(() => {

--- a/src/components/Profile/UserPollsFeed.tsx
+++ b/src/components/Profile/UserPollsFeed.tsx
@@ -3,6 +3,7 @@ import { Event, Filter } from "nostr-tools";
 import { Box, Typography } from "@mui/material";
 import { dataLayer } from "@formstr/local-relay";
 import { useRelayRefresh } from "../../dataLayer/hooks";
+import { isRelayHydrated } from "../../dataLayer/relayRefresh";
 import PollResponseForm from "../PollResponse/PollResponseForm";
 import UnifiedFeed from "../Feed/UnifiedFeed";
 
@@ -40,11 +41,19 @@ const UserPollsFeed: React.FC<UserPollsFeedProps> = ({ pubkey, scrollContainerRe
         });
       },
       onEose() {
-        setLoading(false);
+        // A pre-hydration EOSE means the store was still loading, not
+        // actually empty — the relayRefresh-dep re-run below retries once
+        // hydration completes, so hold off on clearing the spinner here.
+        if (isRelayHydrated()) setLoading(false);
       },
     });
 
-    return () => handle.unobserve();
+    // Safety net: don't let a stuck hydration signal spin forever.
+    const timeout = setTimeout(() => setLoading(false), 8000);
+    return () => {
+      handle.unobserve();
+      clearTimeout(timeout);
+    };
   }, [pubkey, relayRefresh]);
 
   useEffect(() => {

--- a/src/components/Profile/UserRatingsGiven.tsx
+++ b/src/components/Profile/UserRatingsGiven.tsx
@@ -3,6 +3,7 @@ import { Event, Filter } from "nostr-tools";
 import { Box, Typography } from "@mui/material";
 import { dataLayer } from "@formstr/local-relay";
 import { useRelayRefresh } from "../../dataLayer/hooks";
+import { isRelayHydrated } from "../../dataLayer/relayRefresh";
 import ReviewCard from "../Ratings/ReviewCard";
 import UnifiedFeed from "../Feed/UnifiedFeed";
 
@@ -40,11 +41,19 @@ const UserRatingsGiven: React.FC<UserRatingsGivenProps> = ({ pubkey, scrollConta
         });
       },
       onEose() {
-        setLoading(false);
+        // A pre-hydration EOSE means the store was still loading, not
+        // actually empty — the relayRefresh-dep re-run below retries once
+        // hydration completes, so hold off on clearing the spinner here.
+        if (isRelayHydrated()) setLoading(false);
       },
     });
 
-    return () => handle.unobserve();
+    // Safety net: don't let a stuck hydration signal spin forever.
+    const timeout = setTimeout(() => setLoading(false), 8000);
+    return () => {
+      handle.unobserve();
+      clearTimeout(timeout);
+    };
   }, [pubkey, relayRefresh]);
 
   useEffect(() => {

--- a/src/components/Profile/UserRatingsGiven.tsx
+++ b/src/components/Profile/UserRatingsGiven.tsx
@@ -54,6 +54,9 @@ const UserRatingsGiven: React.FC<UserRatingsGivenProps> = ({ pubkey, scrollConta
       handle.unobserve();
       clearTimeout(timeout);
     };
+    // relayRefresh isn't read in the body — it's a dependency purely to force
+    // a fresh fetchRatings identity (and re-run below) once hydration completes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pubkey, relayRefresh]);
 
   useEffect(() => {

--- a/src/components/Profile/UserRatingsGiven.tsx
+++ b/src/components/Profile/UserRatingsGiven.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState, useCallback } from "react";
 import { Event, Filter } from "nostr-tools";
 import { Box, Typography } from "@mui/material";
 import { dataLayer } from "@formstr/local-relay";
+import { useRelayRefresh } from "../../dataLayer/hooks";
 import ReviewCard from "../Ratings/ReviewCard";
 import UnifiedFeed from "../Feed/UnifiedFeed";
 
@@ -16,6 +17,7 @@ const KIND_RATING = 34259;
 const UserRatingsGiven: React.FC<UserRatingsGivenProps> = ({ pubkey, scrollContainerRef }) => {
   const [ratings, setRatings] = useState<Event[]>([]);
   const [loading, setLoading] = useState(true);
+  const relayRefresh = useRelayRefresh();
 
   const fetchRatings = useCallback(() => {
     if (!pubkey) return;
@@ -43,7 +45,7 @@ const UserRatingsGiven: React.FC<UserRatingsGivenProps> = ({ pubkey, scrollConta
     });
 
     return () => handle.unobserve();
-  }, [pubkey]);
+  }, [pubkey, relayRefresh]);
 
   useEffect(() => {
     const cleanup = fetchRatings();

--- a/src/dataLayer/bootstrap.ts
+++ b/src/dataLayer/bootstrap.ts
@@ -18,7 +18,7 @@ import {
 } from "@formstr/local-relay";
 import { signerManager } from "../singletons/Signer/SignerManager";
 import { defaultRelays, searchRelays } from "../nostr";
-import { notifyRelayRefresh, subscribeRelayRefresh } from "./relayRefresh";
+import { notifyRelayRefresh, subscribeRelayRefresh, markRelayHydrated } from "./relayRefresh";
 
 let started = false;
 
@@ -46,6 +46,7 @@ export function bootstrapDataLayer(): DataLayer {
       baseChannel.onMessage((m) => {
         const kind = (m as { kind?: string } | null)?.kind;
         if (kind === "hydrated") {
+          markRelayHydrated();
           notifyRelayRefresh();
         } else if (kind === "ready") {
           readyCount += 1;

--- a/src/dataLayer/hooks.tsx
+++ b/src/dataLayer/hooks.tsx
@@ -23,7 +23,7 @@ import {
   type Scope,
   type ScopeUser,
 } from "@formstr/local-relay";
-import { getRelayRefresh, subscribeRelayRefresh } from "./relayRefresh";
+import { getRelayRefresh, subscribeRelayRefresh, isRelayHydrated } from "./relayRefresh";
 
 /**
  * Reactive read of the relay refresh signal — bumps when the worker can newly
@@ -183,7 +183,10 @@ export function useEvents({ kinds, scope, includeNonRoots }: UseEventsOptions): 
       onEose: () => {
         eosedRef.current = true;
         recompute();
-        setLoading(false);
+        // A pre-hydration EOSE means the store was still loading, not actually
+        // empty — stay in `loading` (the `refresh` dep re-runs this effect once
+        // hydration completes) instead of flashing an empty/failed state.
+        if (isRelayHydrated()) setLoading(false);
       },
     });
     handleRef.current = handle;

--- a/src/dataLayer/relayRefresh.ts
+++ b/src/dataLayer/relayRefresh.ts
@@ -15,6 +15,7 @@
  */
 
 let refreshCount = 0;
+let hydrated = false;
 const listeners = new Set<() => void>();
 
 /** Bump the signal — call when the worker can newly serve more cached data. */
@@ -26,6 +27,21 @@ export function notifyRelayRefresh(): void {
 /** Current signal value (changes identity-stably as a number). */
 export function getRelayRefresh(): number {
   return refreshCount;
+}
+
+/**
+ * Mark IndexedDB hydration as complete. Consumers use this to hold off
+ * declaring "no results" until the store has actually finished loading —
+ * otherwise a pre-hydration EOSE flashes an empty/failed state right before
+ * the retry (driven by `notifyRelayRefresh`) paints the real data.
+ */
+export function markRelayHydrated(): void {
+  hydrated = true;
+}
+
+/** True once IndexedDB hydration has completed at least once this session. */
+export function isRelayHydrated(): boolean {
+  return hydrated;
 }
 
 /** Subscribe to refreshes; returns an unsubscribe fn (useSyncExternalStore shape). */

--- a/src/hooks/useMyTopicsFeed.tsx
+++ b/src/hooks/useMyTopicsFeed.tsx
@@ -5,6 +5,7 @@ import { Event } from "nostr-tools";
 import { dataLayer, type ObserveHandle } from "@formstr/local-relay";
 import { collectOnce } from "../dataLayer/collect";
 import { useRelays } from "./useRelays";
+import { useRelayRefresh } from "../dataLayer/hooks";
 import { useUserContext } from "./useUserContext";
 import { signEvent } from "../nostr";
 import {
@@ -30,6 +31,7 @@ type FeedMode = "unfiltered" | "global" | "contacts";
 export function useMyTopicsFeed(myTopics: Set<string>) {
   const { relays } = useRelays();
   const { user, requestLogin } = useUserContext();
+  const relayRefresh = useRelayRefresh();
 
   const [notes, setNotes] = useState<Map<string, TopicNote>>(new Map());
   const [feedMode, setFeedMode] = useState<FeedMode>("global");
@@ -320,7 +322,7 @@ export function useMyTopicsFeed(myTopics: Set<string>) {
       moderationDirtyRef.current = false;
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [relays, myTopics]);
+  }, [relays, myTopics, relayRefresh]);
 
   useEffect(() => {
     const cleanup = startSubscription();

--- a/src/hooks/useMyTopicsFeed.tsx
+++ b/src/hooks/useMyTopicsFeed.tsx
@@ -6,6 +6,7 @@ import { dataLayer, type ObserveHandle } from "@formstr/local-relay";
 import { collectOnce } from "../dataLayer/collect";
 import { useRelays } from "./useRelays";
 import { useRelayRefresh } from "../dataLayer/hooks";
+import { isRelayHydrated } from "../dataLayer/relayRefresh";
 import { useUserContext } from "./useUserContext";
 import { signEvent } from "../nostr";
 import {
@@ -260,6 +261,11 @@ export function useMyTopicsFeed(myTopics: Set<string>) {
       ],
       {
         onEose: () => {
+          // A pre-hydration EOSE means the store was still loading, not
+          // actually empty — the relayRefresh-dep restart (below) retries once
+          // hydration completes, so hold off on clearing the spinner here.
+          // The hard timeout further down still fires regardless.
+          if (!isRelayHydrated()) return;
           initialLoadDoneRef.current = true;
           if (fresh) {
             setRefreshing(false);


### PR DESCRIPTION
@abh3po If someone directly open polls feed form the search bar it gives an error. The core issue was a race condition between our UI components and the background worker. Feed components that utilized dataLayer.observe directly (bypassing the useEvents wrapper) were subscribing to the worker's cache before it had finished hydrating from IndexedDB. Because the cache was technically empty at that millisecond, the worker immediately returned an EOSE (End of Stored Events). The components accepted this empty array, set their loading states to false, and got stuck in an empty state.
<img width="1906" height="792" alt="image" src="https://github.com/user-attachments/assets/a420339f-47d0-49d6-a56b-1ef0e5f25c04" />
