### PR TITLE
Add bookmark feature for events and packs via NIP-53 kind-10003

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,6 +58,7 @@ import ProfilesFeed from "./components/Feed/ProfileFeed";
 import { PollFeed } from "./components/Feed/PollFeed";
 import MoviesFeed from "./components/Feed/MoviesFeed";
 import FollowPacksFeed from "./components/Feed/FollowPacksFeed";
+import BookmarksFeed from "./components/Feed/BookmarksFeed";
 import FollowPackDetail from "./components/FollowPacks/FollowPackDetail";
 import ArticlesFeed from "./components/Feed/ArticlesFeed";
 import MusicFeed from "./components/Feed/MusicFeed";
@@ -247,6 +248,7 @@ function AppContent() {
             <Route path="polls" element={<PollFeed />} />
             <Route path="follow-packs" element={<FollowPacksFeed />} />
             <Route path="follow-packs/:naddr" element={<FollowPackDetail />} />
+            <Route path="bookmarks" element={<BookmarksFeed />} />
             <Route path="articles" element={<ArticlesFeed />} />
             <Route path="articles/:naddr" element={<ArticleDetail />} />
             <Route path="music" element={<MusicFeed />} />

--- a/src/components/Common/Bookmark/BookmarkButton.tsx
+++ b/src/components/Common/Bookmark/BookmarkButton.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { CircularProgress, IconButton, Tooltip, Typography, useTheme } from "@mui/material";
 import BookmarkBorderIcon from "@mui/icons-material/BookmarkBorder";
 import BookmarkIcon from "@mui/icons-material/Bookmark";
@@ -23,9 +23,26 @@ export const BookmarkButton: React.FC<BookmarkButtonProps> = ({ event }) => {
   const ref = eventRefOf(event);
   const isBookmarked = bookmarkedEventRefs.has(ref);
   const bookmarkCount = getBookmarkCount(ref);
+  const buttonRef = useRef<HTMLDivElement>(null);
 
+  // Fetch the count only when the button is actually on screen: the
+  // author-less kind-10003 count query is one of the heavier interests, and
+  // offscreen cards shouldn't pay for it. The context layer applies its own
+  // 5-minute TTL on top, so re-entering the viewport re-checks cheaply.
   useEffect(() => {
-    fetchBookmarkCountThrottled(ref);
+    const el = buttonRef.current;
+    if (!el || typeof IntersectionObserver === "undefined") {
+      fetchBookmarkCountThrottled(ref);
+      return;
+    }
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((en) => en.isIntersecting)) fetchBookmarkCountThrottled(ref);
+      },
+      { rootMargin: "200px" },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
   }, [ref, fetchBookmarkCountThrottled]);
 
   const handleClick = async (e: React.MouseEvent) => {
@@ -53,6 +70,7 @@ export const BookmarkButton: React.FC<BookmarkButtonProps> = ({ event }) => {
 
   return (
     <div
+      ref={buttonRef}
       style={{
         display: "flex",
         flexDirection: "row",
@@ -61,7 +79,12 @@ export const BookmarkButton: React.FC<BookmarkButtonProps> = ({ event }) => {
       }}
     >
       <Tooltip title={isBookmarked ? "Remove bookmark" : "Bookmark"}>
-        <IconButton size="small" disabled={pending} onClick={handleClick} color={isBookmarked ? "primary" : "default"}>
+        <IconButton
+          size="small"
+          disabled={pending}
+          onClick={handleClick}
+          color={isBookmarked ? "primary" : "default"}
+        >
           {pending ? (
             <CircularProgress size={18} color="inherit" />
           ) : isBookmarked ? (

--- a/src/components/Common/Bookmark/BookmarkButton.tsx
+++ b/src/components/Common/Bookmark/BookmarkButton.tsx
@@ -1,0 +1,64 @@
+import React, { useState } from "react";
+import { CircularProgress, IconButton, Tooltip } from "@mui/material";
+import BookmarkBorderIcon from "@mui/icons-material/BookmarkBorder";
+import BookmarkIcon from "@mui/icons-material/Bookmark";
+import { Event } from "nostr-tools";
+import { useListContext, eventRefOf } from "../../../hooks/useListContext";
+import { useNotification } from "../../../contexts/notification-context";
+import { useUserContext } from "../../../hooks/useUserContext";
+
+interface BookmarkButtonProps {
+  event: Event;
+}
+
+export const BookmarkButton: React.FC<BookmarkButtonProps> = ({ event }) => {
+  const { bookmarkedEventRefs, bookmarkEvent, unbookmarkEvent } = useListContext();
+  const { user, requestLogin: openLogin } = useUserContext();
+  const { showNotification } = useNotification();
+  const [pending, setPending] = useState(false);
+
+  const ref = eventRefOf(event);
+  const isBookmarked = bookmarkedEventRefs.has(ref);
+
+  const handleClick = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (pending) return;
+    if (!user) {
+      openLogin();
+      return;
+    }
+    setPending(true);
+    try {
+      if (isBookmarked) {
+        await unbookmarkEvent(event);
+        showNotification("Removed bookmark", "success", 2500);
+      } else {
+        await bookmarkEvent(event);
+        showNotification("Bookmarked", "success", 2500);
+      }
+    } catch {
+      showNotification("Couldn't update bookmark — try again", "error", 3000);
+    } finally {
+      setPending(false);
+    }
+  };
+
+  return (
+    <Tooltip title={isBookmarked ? "Remove bookmark" : "Bookmark"}>
+      <IconButton
+        size="small"
+        disabled={pending}
+        onClick={handleClick}
+        color={isBookmarked ? "primary" : "default"}
+      >
+        {pending ? (
+          <CircularProgress size={18} color="inherit" />
+        ) : isBookmarked ? (
+          <BookmarkIcon />
+        ) : (
+          <BookmarkBorderIcon />
+        )}
+      </IconButton>
+    </Tooltip>
+  );
+};

--- a/src/components/Common/Bookmark/BookmarkButton.tsx
+++ b/src/components/Common/Bookmark/BookmarkButton.tsx
@@ -1,11 +1,12 @@
-import React, { useState } from "react";
-import { CircularProgress, IconButton, Tooltip } from "@mui/material";
+import React, { useEffect, useState } from "react";
+import { CircularProgress, IconButton, Tooltip, Typography, useTheme } from "@mui/material";
 import BookmarkBorderIcon from "@mui/icons-material/BookmarkBorder";
 import BookmarkIcon from "@mui/icons-material/Bookmark";
 import { Event } from "nostr-tools";
 import { useListContext, eventRefOf } from "../../../hooks/useListContext";
 import { useNotification } from "../../../contexts/notification-context";
 import { useUserContext } from "../../../hooks/useUserContext";
+import { useAppContext } from "../../../hooks/useAppContext";
 
 interface BookmarkButtonProps {
   event: Event;
@@ -15,10 +16,17 @@ export const BookmarkButton: React.FC<BookmarkButtonProps> = ({ event }) => {
   const { bookmarkedEventRefs, bookmarkEvent, unbookmarkEvent } = useListContext();
   const { user, requestLogin: openLogin } = useUserContext();
   const { showNotification } = useNotification();
+  const { getBookmarkCount, fetchBookmarkCountThrottled } = useAppContext();
+  const theme = useTheme();
   const [pending, setPending] = useState(false);
 
   const ref = eventRefOf(event);
   const isBookmarked = bookmarkedEventRefs.has(ref);
+  const bookmarkCount = getBookmarkCount(ref);
+
+  useEffect(() => {
+    fetchBookmarkCountThrottled(ref);
+  }, [ref, fetchBookmarkCountThrottled]);
 
   const handleClick = async (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -44,21 +52,33 @@ export const BookmarkButton: React.FC<BookmarkButtonProps> = ({ event }) => {
   };
 
   return (
-    <Tooltip title={isBookmarked ? "Remove bookmark" : "Bookmark"}>
-      <IconButton
-        size="small"
-        disabled={pending}
-        onClick={handleClick}
-        color={isBookmarked ? "primary" : "default"}
-      >
-        {pending ? (
-          <CircularProgress size={18} color="inherit" />
-        ) : isBookmarked ? (
-          <BookmarkIcon />
-        ) : (
-          <BookmarkBorderIcon />
-        )}
-      </IconButton>
-    </Tooltip>
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "row",
+        alignItems: "center",
+        gap: 4,
+      }}
+    >
+      <Tooltip title={isBookmarked ? "Remove bookmark" : "Bookmark"}>
+        <IconButton size="small" disabled={pending} onClick={handleClick} color={isBookmarked ? "primary" : "default"}>
+          {pending ? (
+            <CircularProgress size={18} color="inherit" />
+          ) : isBookmarked ? (
+            <BookmarkIcon />
+          ) : (
+            <BookmarkBorderIcon />
+          )}
+        </IconButton>
+      </Tooltip>
+      {bookmarkCount > 0 && (
+        <Typography
+          variant="caption"
+          sx={{ color: isBookmarked ? theme.palette.primary.main : "inherit" }}
+        >
+          {bookmarkCount}
+        </Typography>
+      )}
+    </div>
   );
 };

--- a/src/components/Common/Likes/likes.tsx
+++ b/src/components/Common/Likes/likes.tsx
@@ -194,18 +194,20 @@ const Likes: React.FC<LikesProps> = ({ pollEvent }) => {
           {/* Top 2 emojis next to button — clicking the cluster (incl. the
               "+x" badge) opens the reactions details modal instead of the
               emoji picker. stopPropagation keeps the parent's click (which
-              opens the picker) from also firing. */}
+              opens the picker) from also firing. Only rendered when there are
+              reactions; an empty cluster would still carry its ml margin and
+              widen the row gap. */}
+          {hasReactions && (
           <Box
             display="flex"
             alignItems="center"
             ml={1}
             gap={0.5}
             onClick={(e) => {
-              if (!hasReactions) return;
               e.stopPropagation();
               setShowDetails(true);
             }}
-            sx={hasReactions ? { cursor: "pointer" } : undefined}
+            sx={{ cursor: "pointer" }}
           >
             {topEmojis.slice(0, 2).map((r) => (
               <span key={r.emoji} style={{ fontSize: 18 }}>
@@ -230,6 +232,7 @@ const Likes: React.FC<LikesProps> = ({ pollEvent }) => {
               </span>
             )}
           </Box>
+          )}
         </Box>
       </Tooltip>
 

--- a/src/components/Common/Likes/likes.tsx
+++ b/src/components/Common/Likes/likes.tsx
@@ -164,9 +164,8 @@ const Likes: React.FC<LikesProps> = ({ pollEvent }) => {
     <Box
       display="flex"
       alignItems="center"
-      ml={2}
       position="relative"
-      sx={{ p: 0, my: -5 }}
+      sx={{ p: 0 }}
     >
       <Tooltip title={tooltipTitle}>
         <Box

--- a/src/components/Common/Repost/reposts.tsx
+++ b/src/components/Common/Repost/reposts.tsx
@@ -130,7 +130,6 @@ const RepostButton: React.FC<RepostButtonProps> = ({ event }) => {
   return (
     <div
       style={{
-        marginLeft: 20,
         display: "flex",
         flexDirection: "row",
         alignItems: "center",

--- a/src/components/Common/Share/ShareButton.tsx
+++ b/src/components/Common/Share/ShareButton.tsx
@@ -68,7 +68,11 @@ const ShareButton: React.FC<ShareButtonProps> = ({ event }) => {
               padding: 2,
             }}
           >
-            <SendIcon sx={{ fontSize: 20, transform: "rotate(-45deg)" }} />
+            {/* translateY lifts the optical center: the paper-plane glyph is
+                bottom-heavy, and the -45° rotation leaves its mass below the
+                box center, so it reads as sitting lower than the siblings.
+                translate applies in screen space (after the rotate). */}
+            <SendIcon sx={{ fontSize: 20, transform: "translateY(-2px) rotate(-45deg)" }} />
           </span>
         </Tooltip>
       </div>

--- a/src/components/Common/Share/ShareButton.tsx
+++ b/src/components/Common/Share/ShareButton.tsx
@@ -58,7 +58,7 @@ const ShareButton: React.FC<ShareButtonProps> = ({ event }) => {
 
   return (
     <>
-      <div style={{ marginLeft: 20, marginTop: -5 }}>
+      <div style={{ display: "flex", alignItems: "center" }}>
         <Tooltip title="Share via DM" onClick={handleClick}>
           <span
             style={{

--- a/src/components/Common/Zaps/zaps.tsx
+++ b/src/components/Common/Zaps/zaps.tsx
@@ -236,7 +236,7 @@ const Zap: React.FC<ZapProps> = ({ pollEvent }) => {
   };
 
   return (
-    <Wrapper style={{ marginLeft: 20 }}>
+    <Wrapper>
       <span style={{ display: "flex", flexDirection: "row", alignItems: "center" }}>
         <Tooltip title="Tap to zap · Hold to charge up the amount">
           <span

--- a/src/components/Feed/BookmarksFeed.tsx
+++ b/src/components/Feed/BookmarksFeed.tsx
@@ -1,0 +1,219 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Event, Filter } from "nostr-tools";
+import { Box, Button, Typography } from "@mui/material";
+import { dataLayer } from "@formstr/local-relay";
+import { useRelayRefresh } from "../../dataLayer/hooks";
+import { useUserContext } from "../../hooks/useUserContext";
+import { useAppContext } from "../../hooks/useAppContext";
+import { useListContext } from "../../hooks/useListContext";
+import { Notes } from "../Notes";
+import PollResponseForm from "../PollResponse/PollResponseForm";
+import { ArticleCard } from "../Articles/ArticleCard";
+import { MusicCard, KIND_MUSIC } from "../Music/MusicCard";
+import { FollowPackCard } from "../FollowPacks/FollowPackCard";
+import UnifiedFeed from "./UnifiedFeed";
+
+// One bookmarkable item: either a pack (from the private 39089 refs) or an
+// event resolved from a public NIP-53-style ref.
+type BookmarkItem =
+  | { type: "pack"; event: Event }
+  | { type: "resolved"; ref: string; event: Event }
+  | { type: "missing"; ref: string };
+
+const KIND_NOTE = 1;
+const KIND_POLL = 1068;
+const KIND_ARTICLE = 30023;
+const KIND_PACK = 39089;
+
+const RESOLVE_TIMEOUT_MS = 5000;
+
+// Refs are produced by `eventRefOf` in lists-context: a 64-hex third segment
+// is an id reference, anything else is an addressable d-reference.
+const HEX_ID = /^[0-9a-f]{64}$/i;
+
+const refParts = (ref: string) => {
+  const [kind, pubkey, third] = ref.split(":");
+  return { kind, pubkey, third };
+};
+
+const matchRef = (ref: string, event: Event): boolean => {
+  const { kind, pubkey, third } = refParts(ref);
+  if (!kind || !pubkey || !third) return false;
+  return HEX_ID.test(third)
+    ? event.id === third
+    : event.kind === Number(kind) &&
+      event.pubkey === pubkey &&
+      event.tags.some((t) => t[0] === "d" && t[1] === third);
+};
+
+const filtersForRefs = (refs: string[]): Filter[] => {
+  const ids: string[] = [];
+  const dQueries: Filter[] = [];
+  for (const ref of refs) {
+    const { kind, pubkey, third } = refParts(ref);
+    if (!kind || !pubkey || !third) continue;
+    if (HEX_ID.test(third)) ids.push(third);
+    else dQueries.push({ kinds: [Number(kind)], authors: [pubkey], "#d": [third], limit: 1 });
+  }
+  if (ids.length) dQueries.push({ ids, limit: ids.length });
+  return dQueries;
+};
+
+const createdAtOf = (item: BookmarkItem) =>
+  item.type === "missing" ? 0 : item.event.created_at;
+
+const BookmarksItem = React.memo(({ item }: { item: BookmarkItem }) => {
+  let inner: React.ReactNode;
+  if (item.type === "pack") {
+    inner = <FollowPackCard event={item.event} />;
+  } else if (item.type === "missing") {
+    const { kind, pubkey } = refParts(item.ref);
+    inner = (
+      <Box sx={{ p: 2, rounded: 2, border: 1, borderColor: "divider" }}>
+        <Typography variant="body2" color="text.secondary">
+          Bookmark for kind {kind} by {pubkey} is no longer resolvable.
+        </Typography>
+      </Box>
+    );
+  } else {
+    const { event } = item;
+    if (event.kind === KIND_POLL) inner = <PollResponseForm pollEvent={event} />;
+    else if (event.kind === KIND_ARTICLE) inner = <ArticleCard event={event} />;
+    else if (event.kind === KIND_MUSIC) inner = <MusicCard event={event} />;
+    else inner = <Notes event={event} />;
+  }
+  return <Box sx={{ width: "100%" }}>{inner}</Box>;
+});
+
+const BookmarksFeed: React.FC = () => {
+  const { user, requestLogin } = useUserContext();
+  const { fetchUserProfileThrottled, profiles } = useAppContext();
+  const { bookmarkedEventRefs, bookmarkedPackKeys, lists } = useListContext();
+  const relayRefresh = useRelayRefresh();
+
+  const [items, setItems] = useState<BookmarkItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [initialLoadDone, setInitialLoadDone] = useState(false);
+  const resolvingRef = useRef(false);
+
+  // Bookmarked packs come straight from context (already hydrated).
+  const bookmarkedPacks = useMemo(
+    () =>
+      Array.from(lists?.entries() ?? [])
+        .filter(([key, e]) => e.kind === KIND_PACK && bookmarkedPackKeys.has(key))
+        .map(([, e]) => e as Event),
+    [lists, bookmarkedPackKeys]
+  );
+
+  const refList = useMemo(() => Array.from(bookmarkedEventRefs), [bookmarkedEventRefs]);
+
+  const resolve = useCallback(() => {
+    if (resolvingRef.current) return;
+    resolvingRef.current = true;
+    setLoading(true);
+
+    const itemsFromPacks: BookmarkItem[] = bookmarkedPacks.map((event) => ({
+      type: "pack" as const,
+      event,
+    }));
+
+    if (refList.length === 0) {
+      itemsFromPacks.sort((a, b) => createdAtOf(b) - createdAtOf(a));
+      setItems(itemsFromPacks);
+      setInitialLoadDone(true);
+      setLoading(false);
+      resolvingRef.current = false;
+      return;
+    }
+
+    const resolved = new Map<string, Event>();
+    let settled = false;
+    let quietTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const finalize = () => {
+      if (settled) return;
+      settled = true;
+      if (quietTimer) clearTimeout(quietTimer);
+      handle.unobserve();
+      const next: BookmarkItem[] = [
+        ...itemsFromPacks,
+        ...refList.map<BookmarkItem>((ref) =>
+          resolved.has(ref)
+            ? { type: "resolved", ref, event: resolved.get(ref)! }
+            : { type: "missing", ref }
+        ),
+      ];
+      next.sort((a, b) => createdAtOf(b) - createdAtOf(a));
+      setItems(next);
+      setInitialLoadDone(true);
+      setLoading(false);
+      resolvingRef.current = false;
+    };
+
+    const handle = dataLayer.observe(filtersForRefs(refList), {
+      onEvent: (event: Event) => {
+        if (event.kind === KIND_NOTE && !profiles?.get(event.pubkey)) {
+          fetchUserProfileThrottled(event.pubkey);
+        }
+        for (const ref of refList) {
+          if (!resolved.has(ref) && matchRef(ref, event)) {
+            resolved.set(ref, event);
+            break;
+          }
+        }
+        if (quietTimer) clearTimeout(quietTimer);
+        quietTimer = setTimeout(finalize, 900);
+      },
+    });
+
+    // Hard cap so zero-result resolutions still settle.
+    setTimeout(finalize, RESOLVE_TIMEOUT_MS);
+  }, [refList, bookmarkedPacks, fetchUserProfileThrottled, profiles]);
+
+  useEffect(() => {
+    if (user) resolve();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [resolve, relayRefresh]);
+
+  if (!user) {
+    return (
+      <Box
+        display="flex"
+        flexDirection="column"
+        alignItems="center"
+        justifyContent="center"
+        minHeight="200px"
+        gap={2}
+      >
+        <Typography variant="body2" color="text.secondary">
+          Bookmarks are stored on your account.
+        </Typography>
+        <Button variant="contained" onClick={requestLogin}>
+          login to view bookmarks
+        </Button>
+      </Box>
+    );
+  }
+
+  return (
+    <UnifiedFeed
+      data={items}
+      itemContent={(_i, item) => <BookmarksItem item={item} />}
+      computeItemKey={(_i, item) => (item.type === "pack" ? item.event.id : item.ref)}
+      loading={loading}
+      loadingMore={false}
+      emptyState={
+        initialLoadDone ? (
+          <Box display="flex" justifyContent="center" px={3} py={8}>
+            <Typography variant="body2" color="text.secondary" textAlign="center">
+              No bookmarks yet. Bookmark notes, polls, or articles from anywhere in
+              the app.
+            </Typography>
+          </Box>
+        ) : undefined
+      }
+    />
+  );
+};
+
+export default BookmarksFeed;

--- a/src/components/Feed/BookmarksFeed.tsx
+++ b/src/components/Feed/BookmarksFeed.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Event, Filter } from "nostr-tools";
+import { Event, Filter, nip19 } from "nostr-tools";
 import { Box, Button, Typography } from "@mui/material";
 import { dataLayer } from "@formstr/local-relay";
 import { useRelayRefresh } from "../../dataLayer/hooks";
@@ -14,7 +14,7 @@ import { FollowPackCard } from "../FollowPacks/FollowPackCard";
 import UnifiedFeed from "./UnifiedFeed";
 
 // One bookmarkable item: either a pack (from the private 39089 refs) or an
-// event resolved from a public NIP-53-style ref.
+// event resolved from a public NIP-51 ref.
 type BookmarkItem =
   | { type: "pack"; event: Event }
   | { type: "resolved"; ref: string; event: Event }
@@ -27,60 +27,101 @@ const KIND_PACK = 39089;
 
 const RESOLVE_TIMEOUT_MS = 5000;
 
-// Refs are produced by `eventRefOf` in lists-context: a 64-hex third segment
-// is an id reference, anything else is an addressable d-reference.
+// Refs follow the NIP-51 bookmark shape produced by `eventRefOf` in
+// lists-context: a bare 64-hex id (plain events, stored as `e` tags) or a
+// canonical `kind:pubkey:identifier` a-ref (addressable kinds).
 const HEX_ID = /^[0-9a-f]{64}$/i;
 
-const refParts = (ref: string) => {
-  const [kind, pubkey, third] = ref.split(":");
-  return { kind, pubkey, third };
+type RefParts = { kind: number; pubkey: string; identifier: string } | null;
+
+const refParts = (ref: string): RefParts => {
+  const [kind, pubkey, ...rest] = ref.split(":");
+  const identifier = rest.join(":");
+  if (!/^\d+$/.test(kind) || !pubkey || !identifier) return null;
+  return { kind: Number(kind), pubkey, identifier };
 };
 
 const matchRef = (ref: string, event: Event): boolean => {
-  const { kind, pubkey, third } = refParts(ref);
-  if (!kind || !pubkey || !third) return false;
-  return HEX_ID.test(third)
-    ? event.id === third
-    : event.kind === Number(kind) &&
-      event.pubkey === pubkey &&
-      event.tags.some((t) => t[0] === "d" && t[1] === third);
+  if (HEX_ID.test(ref)) return event.id === ref;
+  const parts = refParts(ref);
+  if (!parts) return false;
+  return (
+    event.kind === parts.kind &&
+    event.pubkey === parts.pubkey &&
+    event.tags.some((t) => t[0] === "d" && t[1] === parts.identifier)
+  );
 };
 
 const filtersForRefs = (refs: string[]): Filter[] => {
-  const ids: string[] = [];
-  const dQueries: Filter[] = [];
+  const ids = refs.filter((r) => HEX_ID.test(r));
+  const filters: Filter[] = [];
+  if (ids.length) filters.push({ ids, limit: ids.length });
   for (const ref of refs) {
-    const { kind, pubkey, third } = refParts(ref);
-    if (!kind || !pubkey || !third) continue;
-    if (HEX_ID.test(third)) ids.push(third);
-    else dQueries.push({ kinds: [Number(kind)], authors: [pubkey], "#d": [third], limit: 1 });
+    const parts = refParts(ref);
+    if (parts) {
+      filters.push({ kinds: [parts.kind], authors: [parts.pubkey], "#d": [parts.identifier], limit: 1 });
+    }
   }
-  if (ids.length) dQueries.push({ ids, limit: ids.length });
-  return dQueries;
+  return filters;
+};
+
+// Kinds this client can render in the bookmarks feed. `eventRefOf` bookmarks
+// anything, so anything unlisted here (and addressable kinds without a card)
+// falls through to the generic note renderer.
+// Single place to extend when a new bookmarkable kind gains a renderer.
+const KIND_RENDERERS: Record<number, (event: Event) => React.ReactNode> = {
+  [KIND_POLL]: (event) => <PollResponseForm pollEvent={event} />,
+  [KIND_ARTICLE]: (event) => <ArticleCard event={event} />,
+  [KIND_MUSIC]: (event) => <MusicCard event={event} />,
 };
 
 const createdAtOf = (item: BookmarkItem) =>
   item.type === "missing" ? 0 : item.event.created_at;
+
+// Friendly rendering for refs that no longer resolve (deleted events, relays
+// unreachable, or legacy refs pointing at gone content): a truncated npub
+// plus a link to an external explorer for the full id.
+const MissingBookmark = ({ refString }: { refString: string }) => {
+  const parts = refParts(refString);
+  const npub = parts ? nip19.nprofileEncode({ pubkey: parts.pubkey }) : null;
+  const short = npub ? `${npub.slice(0, 10)}…${npub.slice(-6)}` : refString.slice(0, 16);
+  const explorerUrl = HEX_ID.test(refString)
+    ? `https://nostr.band/${refString}`
+    : parts
+    ? `https://nostr.band/${nip19.npubEncode(parts.pubkey)}`
+    : null;
+  return (
+    <Box sx={{ p: 2, borderRadius: 2, border: 1, borderColor: "divider" }}>
+      <Typography variant="body2" color="text.secondary">
+        {parts
+          ? `Bookmark for a kind ${parts.kind} event by ${short}`
+          : `Bookmark ${short}`}{" "}
+        is no longer resolvable.
+        {explorerUrl && (
+          <Button
+            size="small"
+            href={explorerUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            sx={{ ml: 1, textTransform: "none", fontSize: "0.75rem" }}
+          >
+            Open in explorer
+          </Button>
+        )}
+      </Typography>
+    </Box>
+  );
+};
 
 const BookmarksItem = React.memo(({ item }: { item: BookmarkItem }) => {
   let inner: React.ReactNode;
   if (item.type === "pack") {
     inner = <FollowPackCard event={item.event} />;
   } else if (item.type === "missing") {
-    const { kind, pubkey } = refParts(item.ref);
-    inner = (
-      <Box sx={{ p: 2, rounded: 2, border: 1, borderColor: "divider" }}>
-        <Typography variant="body2" color="text.secondary">
-          Bookmark for kind {kind} by {pubkey} is no longer resolvable.
-        </Typography>
-      </Box>
-    );
+    inner = <MissingBookmark refString={item.ref} />;
   } else {
     const { event } = item;
-    if (event.kind === KIND_POLL) inner = <PollResponseForm pollEvent={event} />;
-    else if (event.kind === KIND_ARTICLE) inner = <ArticleCard event={event} />;
-    else if (event.kind === KIND_MUSIC) inner = <MusicCard event={event} />;
-    else inner = <Notes event={event} />;
+    inner = KIND_RENDERERS[event.kind]?.(event) ?? <Notes event={event} />;
   }
   return <Box sx={{ width: "100%" }}>{inner}</Box>;
 });
@@ -106,6 +147,12 @@ const BookmarksFeed: React.FC = () => {
   );
 
   const refList = useMemo(() => Array.from(bookmarkedEventRefs), [bookmarkedEventRefs]);
+
+  // The resolve effect reads profiles only to skip redundant author fetches —
+  // tracking it in a ref keeps the (expensive) resolve callback from being
+  // rebuilt every time any profile arrives.
+  const profilesRef = useRef(profiles);
+  profilesRef.current = profiles;
 
   const resolve = useCallback(() => {
     if (resolvingRef.current) return;
@@ -152,7 +199,7 @@ const BookmarksFeed: React.FC = () => {
 
     const handle = dataLayer.observe(filtersForRefs(refList), {
       onEvent: (event: Event) => {
-        if (event.kind === KIND_NOTE && !profiles?.get(event.pubkey)) {
+        if (event.kind === KIND_NOTE && !profilesRef.current?.get(event.pubkey)) {
           fetchUserProfileThrottled(event.pubkey);
         }
         for (const ref of refList) {
@@ -168,7 +215,7 @@ const BookmarksFeed: React.FC = () => {
 
     // Hard cap so zero-result resolutions still settle.
     setTimeout(finalize, RESOLVE_TIMEOUT_MS);
-  }, [refList, bookmarkedPacks, fetchUserProfileThrottled, profiles]);
+  }, [refList, bookmarkedPacks, fetchUserProfileThrottled]);
 
   useEffect(() => {
     if (user) resolve();

--- a/src/components/FeedbackMenu/index.tsx
+++ b/src/components/FeedbackMenu/index.tsx
@@ -107,7 +107,7 @@ export const FeedbackMenu: React.FC<FeedbackMenuProps> = ({
             onScroll={handleScroll}
             display="flex"
             alignItems="center"
-            gap={1}
+            gap={1.25}
             sx={{
               overflowX: "auto",
               WebkitOverflowScrolling: "touch",
@@ -135,9 +135,7 @@ export const FeedbackMenu: React.FC<FeedbackMenuProps> = ({
               />
             )}
 
-            <Box display="flex" alignItems="center">
-              <Likes pollEvent={event} />
-            </Box>
+            <Likes pollEvent={event} />
 
             <RepostButton event={event} />
 
@@ -147,9 +145,7 @@ export const FeedbackMenu: React.FC<FeedbackMenuProps> = ({
 
             <Zap pollEvent={event} />
 
-            <Box sx={{ ml: 1.5, mt: 0.3 }}>
-              <RatingPopover entityId={event.id} entityType="event" iconSize={26} />
-            </Box>
+            <RatingPopover entityId={event.id} entityType="event" iconSize={26} />
           </Box>
 
           {/* Scroll-left indicator */}

--- a/src/components/FeedbackMenu/index.tsx
+++ b/src/components/FeedbackMenu/index.tsx
@@ -19,6 +19,7 @@ import { Event, nip19 } from "nostr-tools";
 import { useNavigate } from "react-router-dom";
 import RepostButton from "../Common/Repost/reposts";
 import ShareButton from "../Common/Share/ShareButton";
+import { BookmarkButton } from "../Common/Bookmark/BookmarkButton";
 
 interface FeedbackMenuProps {
   event: Event;
@@ -141,6 +142,8 @@ export const FeedbackMenu: React.FC<FeedbackMenuProps> = ({
             <RepostButton event={event} />
 
             <ShareButton event={event} />
+
+            <BookmarkButton event={event} />
 
             <Zap pollEvent={event} />
 

--- a/src/components/Login/LoginModal.tsx
+++ b/src/components/Login/LoginModal.tsx
@@ -69,6 +69,7 @@ const NOSTRCONNECT_PERMS = [
   "sign_event:1059",
   "sign_event:9735",
   "sign_event:10050",
+  "sign_event:10003",
   "nip04_encrypt",
   "nip04_decrypt",
   "nip44_encrypt",

--- a/src/components/SidePane/index.tsx
+++ b/src/components/SidePane/index.tsx
@@ -18,6 +18,7 @@ import BookIcon from "@mui/icons-material/MenuBook";
 import MovieIcon from "@mui/icons-material/Movie";
 import MusicNoteIcon from "@mui/icons-material/MusicNote";
 import PeopleIcon from "@mui/icons-material/People";
+import BookmarkIcon from "@mui/icons-material/Bookmark";
 import SportsEsportsIcon from "@mui/icons-material/SportsEsports";
 import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
 import { SvgIconComponent } from "@mui/icons-material";
@@ -94,6 +95,7 @@ const feedOptions: { value: string; label: string; Icon: SvgIconComponent }[] = 
   { value: "music",        label: "Music",        Icon: MusicNoteIcon },
   { value: "movies",       label: "Movies",       Icon: MovieIcon },
   { value: "follow-packs", label: "Packs",        Icon: PeopleIcon },
+  { value: "bookmarks",    label: "Bookmarks",    Icon: BookmarkIcon },
   { value: "games",        label: "Games",        Icon: SportsEsportsIcon },
 ];
 

--- a/src/contexts/app-context.tsx
+++ b/src/contexts/app-context.tsx
@@ -11,8 +11,9 @@ type AppContextInterface = {
   likesMap: Map<string, Event[]>;
   zapsMap: Map<string, Event[]>;
   repostsMap: Map<string, Event[]>;
-  // NIP-53 bookmark lists (kind 10003), indexed by the `a`-tag event ref they
-  // reference. A count of distinct authors bookmarking one event comes from here.
+  // NIP-51 bookmark lists (kind 10003), indexed by both tag spellings they
+  // may carry: event ids (`e`) and addressable a-refs. A count of distinct
+  // authors bookmarking one event comes from here.
   bookmarksMap: Map<string, Event[]>;
   getBookmarkCount: (eventRef: string) => number;
   getProfile: (pubkey: string) => Profile | undefined;
@@ -51,6 +52,11 @@ interface Interest {
   timer: ReturnType<typeof setTimeout> | null;
 }
 const newInterest = (): Interest => ({ ids: new Set(), handle: null, timer: null });
+
+// How long a bookmark-count ref stays fetched before the interest re-arms for
+// it — keeps the author-less kind-10003 count queries from re-firing on every
+// feed scroll while still going live again eventually.
+const BOOKMARK_COUNT_TTL_MS = 5 * 60 * 1000;
 
 export function AppContextProvider({ children }: { children: ReactNode }) {
   const [aiSettings, setAISettings] = useState(
@@ -119,6 +125,8 @@ export function AppContextProvider({ children }: { children: ReactNode }) {
     reposts: newInterest(),
     bookmarks: newInterest(),
   });
+  // Last-fetch timestamps for bookmark-count refs (TTL enforcement).
+  const bookmarkCountFetchedAt = useRef(new Map<string, number>());
 
   const addToInterest = useCallback(
     (
@@ -185,12 +193,30 @@ export function AppContextProvider({ children }: { children: ReactNode }) {
       addToInterest(interests.current.reposts, eventId, (ids) => [{ kinds: [6, 16], "#e": ids }], onDataEvent),
     [addToInterest, onDataEvent],
   );
-  // NIP-53: every user's bookmark list (kind 10003) carries the bookmarked
-  // event as a public `a`-tag. Querying those tags author-less finds every
-  // list that references a given event — the set of bookmarkers.
+  // NIP-51: every user's bookmark list (kind 10003) carries the bookmarked
+  // event as an `e` tag (plain events) or an addressable a-ref. The interest
+  // holds both spellings of every ref so one author-less query pair finds the
+  // bookmarkers; a TTL re-arms the interest periodically so live counts still
+  // update without re-querying on every feed scroll.
   const fetchBookmarkCountThrottled = useCallback(
-    (eventRef: string) =>
-      addToInterest(interests.current.bookmarks, eventRef, (ids) => [{ kinds: [10003], "#a": ids }], onDataEvent),
+    (eventRef: string) => {
+      const interest = interests.current.bookmarks;
+      const now = Date.now();
+      const stamp = bookmarkCountFetchedAt.current.get(eventRef);
+      if (stamp && now - stamp < BOOKMARK_COUNT_TTL_MS && interest.ids.has(eventRef)) return;
+      bookmarkCountFetchedAt.current.set(eventRef, now);
+      addToInterest(
+        interest,
+        eventRef,
+        (ids) => [
+          // `e`-tag refs (notes, polls) and a-ref refs (addressable) in one go;
+          // ids that don't match the shape simply match nothing in a filter.
+          { kinds: [10003], "#e": ids },
+          { kinds: [10003], "#a": ids },
+        ],
+        onDataEvent,
+      );
+    },
     [addToInterest, onDataEvent],
   );
 
@@ -301,13 +327,14 @@ export function AppContextProvider({ children }: { children: ReactNode }) {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const repostsMap = useMemo(() => byETag([6, 16]), [dataVersion]);
 
-  // NIP-53 bookmark lists, indexed by the `a`-tag event ref each one carries.
-  // A single event can appear in many users' lists → array of 10003 events.
+  // NIP-51 bookmark lists, indexed by every ref tag they carry — `e` tags
+  // (plain events) and addressable a-refs alike. One event can appear in many
+  // users' lists → array of 10003 events.
   const bookmarksMap = useMemo(() => {
     const map = new Map<string, Event[]>();
     for (const event of queryStore([10003])) {
       for (const tag of event.tags) {
-        if (tag[0] === "a" && tag[1]) {
+        if ((tag[0] === "a" || tag[0] === "e") && tag[1]) {
           map.set(tag[1], [...(map.get(tag[1]) || []), event]);
         }
       }

--- a/src/contexts/app-context.tsx
+++ b/src/contexts/app-context.tsx
@@ -11,6 +11,10 @@ type AppContextInterface = {
   likesMap: Map<string, Event[]>;
   zapsMap: Map<string, Event[]>;
   repostsMap: Map<string, Event[]>;
+  // NIP-53 bookmark lists (kind 10003), indexed by the `a`-tag event ref they
+  // reference. A count of distinct authors bookmarking one event comes from here.
+  bookmarksMap: Map<string, Event[]>;
+  getBookmarkCount: (eventRef: string) => number;
   getProfile: (pubkey: string) => Profile | undefined;
   getComments: (eventId: string) => Event[];
   getLikes: (eventId: string) => Event[];
@@ -25,6 +29,7 @@ type AppContextInterface = {
   fetchLikesThrottled: (pollEventId: string) => void;
   fetchZapsThrottled: (pollEventId: string) => void;
   fetchRepostsThrottled: (pollEventId: string) => void;
+  fetchBookmarkCountThrottled: (eventRef: string) => void;
   aiSettings: {
     model: string;
   };
@@ -112,6 +117,7 @@ export function AppContextProvider({ children }: { children: ReactNode }) {
     likes: newInterest(),
     zaps: newInterest(),
     reposts: newInterest(),
+    bookmarks: newInterest(),
   });
 
   const addToInterest = useCallback(
@@ -177,6 +183,14 @@ export function AppContextProvider({ children }: { children: ReactNode }) {
   const fetchRepostsThrottled = useCallback(
     (eventId: string) =>
       addToInterest(interests.current.reposts, eventId, (ids) => [{ kinds: [6, 16], "#e": ids }], onDataEvent),
+    [addToInterest, onDataEvent],
+  );
+  // NIP-53: every user's bookmark list (kind 10003) carries the bookmarked
+  // event as a public `a`-tag. Querying those tags author-less finds every
+  // list that references a given event — the set of bookmarkers.
+  const fetchBookmarkCountThrottled = useCallback(
+    (eventRef: string) =>
+      addToInterest(interests.current.bookmarks, eventRef, (ids) => [{ kinds: [10003], "#a": ids }], onDataEvent),
     [addToInterest, onDataEvent],
   );
 
@@ -287,11 +301,29 @@ export function AppContextProvider({ children }: { children: ReactNode }) {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const repostsMap = useMemo(() => byETag([6, 16]), [dataVersion]);
 
+  // NIP-53 bookmark lists, indexed by the `a`-tag event ref each one carries.
+  // A single event can appear in many users' lists → array of 10003 events.
+  const bookmarksMap = useMemo(() => {
+    const map = new Map<string, Event[]>();
+    for (const event of queryStore([10003])) {
+      for (const tag of event.tags) {
+        if (tag[0] === "a" && tag[1]) {
+          map.set(tag[1], [...(map.get(tag[1]) || []), event]);
+        }
+      }
+    }
+    return map;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dataVersion]);
+
   const getProfile = (pubkey: string): Profile | undefined => profiles.get(pubkey);
   const getComments = (eventId: string): Event[] => commentsMap.get(eventId) || [];
   const getLikes = (eventId: string): Event[] => likesMap.get(eventId) || [];
   const getZaps = (eventId: string): Event[] => zapsMap.get(eventId) || [];
   const getReposts = (eventId: string): Event[] => repostsMap.get(eventId) || [];
+  // Distinct users who bookmarked the event ref.
+  const getBookmarkCount = (eventRef: string): number =>
+    new Set((bookmarksMap.get(eventRef) || []).map((e) => e.pubkey)).size;
 
   return (
     <AppContext.Provider
@@ -303,6 +335,8 @@ export function AppContextProvider({ children }: { children: ReactNode }) {
         likesMap,
         zapsMap,
         repostsMap,
+        bookmarksMap,
+        getBookmarkCount,
         getProfile,
         getComments,
         getLikes,
@@ -317,6 +351,7 @@ export function AppContextProvider({ children }: { children: ReactNode }) {
         fetchLikesThrottled,
         fetchZapsThrottled,
         fetchRepostsThrottled,
+        fetchBookmarkCountThrottled,
         aiSettings,
         setAISettings,
         resetStore,

--- a/src/contexts/lists-context.tsx
+++ b/src/contexts/lists-context.tsx
@@ -104,6 +104,27 @@ function migrateLegacyWotCache(pubkey: string): WotCacheRecord | null {
   return record;
 }
 
+// NIP-22 ref for a bookmarkable event: addressable kinds (d-tagged long-form)
+// use their canonical "kind:pubkey:identifier", everything else falls back to
+// the event id so the bookmark stays resolvable.
+export function eventRefOf(event: Event) {
+  if (event.kind >= 30000 && event.tags.some((t) => t[0] === "d")) {
+    return `${event.kind}:${event.pubkey}:${event.tags.find((t) => t[0] === "d")![1]}`;
+  }
+  return `${event.kind}:${event.pubkey}:${event.id}`;
+}
+
+// Heuristic for a public `a` tag that is one of OUR event bookmarks (as opposed
+// to foreign NIP-53 a-tags we must preserve). Our refs carry a third segment:
+// either a d-identifier (addressable kinds) or a full 64-hex event id
+// (non-addressable kinds). Short 2-segment a-tags are ambiguous with other kinds
+// of a-style references and stay untouched either way.
+function isEventRef(ref: string) {
+  const parts = ref.split(":");
+  if (parts.length < 3) return false;
+  return /^39089$/.test(parts[0]) ? parts.length > 3 : !!parts[2];
+}
+
 interface ListContextInterface {
   lists: Map<string, Event> | undefined;
   selectedList: string | undefined;
@@ -127,6 +148,11 @@ interface ListContextInterface {
   bookmarkedPackKeys: Set<string>;
   bookmarkFollowPack: (packEvent: Event) => Promise<void>;
   unbookmarkFollowPack: (packEvent: Event) => Promise<void>;
+  // NIP-53 bookmarks of arbitrary events (notes, polls, articles, …), stored as
+  // public `a` tags on the kind-10003 event.
+  bookmarkedEventRefs: Set<string>;
+  bookmarkEvent: (event: Event) => Promise<void>;
+  unbookmarkEvent: (event: Event) => Promise<void>;
   fetchAndHydratePacks: (adrefs: string[]) => void;
   // Which of the user's own follows follow `pubkey` (the "followed by" set).
   getNetworkFollowers: (pubkey: string) => string[];
@@ -152,6 +178,7 @@ export function ListProvider({ children }: { children: ReactNode }) {
   const [lists, setLists] = useState<Map<string, Event> | undefined>();
   const [selectedList, setSelectedList] = useState<string | undefined>();
   const [bookmarkedPackKeys, setBookmarkedPackKeys] = useState<Set<string>>(new Set());
+  const [bookmarkedEventRefs, setBookmarkedEventRefs] = useState<Set<string>>(new Set());
   const [pendingFollows, setPendingFollows] = useState<Set<string>>(new Set());
   const [bookmarks10003, setBookmarks10003] = useState<Event | null>(null);
   const [myTopics, setMyTopics] = useState<Set<string> | undefined>();
@@ -197,6 +224,7 @@ export function ListProvider({ children }: { children: ReactNode }) {
       setMyTopics(undefined);
       setMyTopicsEvent(undefined);
       setBookmarkedPackKeys(new Set());
+      setBookmarkedEventRefs(new Set());
       setBookmarks10003(null);
       contactHandleRef.current?.unobserve();
       contactHandleRef.current = null;
@@ -367,6 +395,7 @@ export function ListProvider({ children }: { children: ReactNode }) {
 
   const processBookmarksEvent = async (event: Event) => {
     let adrefs: string[] = [];
+    const eventRefs: string[] = [];
 
     // Decrypt private tags from content (NIP-44 encrypted to self)
     if (event.content) {
@@ -388,12 +417,14 @@ export function ListProvider({ children }: { children: ReactNode }) {
     }
 
     // Also read any unencrypted public tags (backwards compat)
-    const publicAdrefs = event.tags
-      .filter((t) => t[0] === "a" && t[1]?.startsWith("39089:"))
-      .map((t) => t[1]);
+    const aTags = event.tags.filter((t) => t[0] === "a" && t[1]);
+    const publicAdrefs = aTags.filter((t) => t[1].startsWith("39089:")).map((t) => t[1]);
+    eventRefs.push(...aTags.filter((t) => !t[1].startsWith("39089:")).map((t) => t[1]));
     const allAdrefs = Array.from(new Set([...adrefs, ...publicAdrefs]));
+    const allEventRefs = Array.from(new Set(eventRefs));
 
     setBookmarkedPackKeys(new Set(allAdrefs));
+    setBookmarkedEventRefs(new Set(allEventRefs));
     fetchAndHydratePacks(allAdrefs);
   };
 
@@ -412,26 +443,114 @@ export function ListProvider({ children }: { children: ReactNode }) {
     });
   };
 
-  const buildAndPublishBookmarks = async (adrefs: string[]): Promise<Event> => {
+  // The latest kind-10003, with a durable fallback — mirroring followPubkey's
+  // contact-list handling. If the in-memory copy is missing/stale (a fetch that
+  // raced a network error resolves empty, and the account-reset effect also
+  // clears it) we must still build on top of the real list, never on top of
+  // nothing.
+  const fetchLatestBookmarks = async (): Promise<Event | null> => {
+    if (!user) return null;
+    const evts = await collectOnce([
+      { kinds: [10003], authors: [user.pubkey], limit: 1 },
+    ]);
+    if (evts.length > 0) {
+      return evts.sort((a, b) => b.created_at - a.created_at)[0];
+    }
+    try {
+      const raw = localStorage.getItem(`pollerama:bookmarks:${user.pubkey}`);
+      if (!raw) return null;
+      return JSON.parse(raw) as Event;
+    } catch {
+      return null;
+    }
+  };
+
+  // Re-merge a fresher list with whatever the UI already holds. Covers a
+  // bookmark added from another client (its ref would otherwise be dropped),
+  // while leaving a genuinely empty existing list empty.
+  const mergeBookmarks = async (
+    existing: Event | null,
+    packs: string[],
+    refs: string[],
+  ): Promise<{ packAdrefs: string[]; eventRefs: string[] }> => {
+    let existingPacks: string[] = [];
+    if (existing?.content) {
+      try {
+        const signer = await signerManager.getSigner();
+        const decrypted = await signer.nip44Decrypt!(user!.pubkey, existing.content);
+        const privateTags: string[][] = JSON.parse(decrypted);
+        if (Array.isArray(privateTags)) {
+          existingPacks = privateTags
+            .filter((t) => Array.isArray(t) && t[0] === "a" && t[1]?.startsWith("39089:"))
+            .map((t) => t[1]);
+        }
+      } catch {
+        // Fall back to public tags below
+      }
+    }
+    const aTags = (existing?.tags ?? []).filter((t) => t[0] === "a" && t[1]);
+    existingPacks = Array.from(
+      new Set([
+        ...existingPacks,
+        ...aTags.filter((t) => t[1].startsWith("39089:")).map((t) => t[1]),
+      ]),
+    );
+    const existingRefs = Array.from(
+      new Set(aTags.filter((t) => !t[1].startsWith("39089:")).map((t) => t[1])),
+    );
+    return {
+      packAdrefs: Array.from(new Set([...existingPacks, ...packs])),
+      eventRefs: Array.from(new Set([...existingRefs, ...refs])),
+    };
+  };
+
+  const buildAndPublishBookmarks = async (
+    packAdrefs: string[],
+    eventRefs: string[] = [],
+  ): Promise<Event> => {
+    // Never build on top of nothing when we know a real list exists: the
+    // initial fetch can resolve empty after a network error (or the account-
+    // reset effect clears the state), and a lone bookmark would then clobber
+    // it. Re-fetch the latest first and merge — the codebase's existing
+    // followPubkey contacts-list pattern.
+    const latest = await fetchLatestBookmarks();
+    const fresh = latest ?? bookmarks10003;
+    const merged = await mergeBookmarks(fresh, packAdrefs, eventRefs);
+
     const signer = await signerManager.getSigner();
     const pubkey = await signer.getPublicKey();
-    const privateTags = adrefs.map((a) => ["a", a]);
+    const privateTags = merged.packAdrefs.map((a) => ["a", a]);
     const encrypted = await signer.nip44Encrypt!(pubkey, JSON.stringify(privateTags));
 
-    // Preserve all existing public tags except our own 39089 a-tags (which are now private).
-    // This ensures we don't wipe pre-existing bookmarks (notes, URLs, hashtags, etc.)
-    // added by other clients.
-    const existingPublicTags = (bookmarks10003?.tags ?? []).filter(
-      (t) => !(t[0] === "a" && t[1]?.startsWith("39089:"))
+    // Preserve all existing public tags except our own 39089 a-tags (which are
+    // now private) and our own event refs (rebuilt from `eventRefs`). Other
+    // clients' a-tags (foreign NIP-53 bookmarks) are kept untouched.
+    const foreignTags = (fresh?.tags ?? []).filter(
+      (t) => !(t[0] === "a" && (t[1]?.startsWith("39089:") || isEventRef(t[1] ?? ""))),
     );
 
+    // Strictly newer than both wall-clock and any known existing list, so the
+    // published event wins over the older one on relay ordering.
+    const baseTs = Math.max(latest?.created_at ?? 0, bookmarks10003?.created_at ?? 0);
     const template: EventTemplate = {
       kind: 10003,
-      created_at: Math.floor(Date.now() / 1000),
-      tags: existingPublicTags,
+      created_at: Math.max(Math.floor(Date.now() / 1000), baseTs + 1),
+      tags: [...foreignTags, ...merged.eventRefs.map((r) => ["a", r])],
       content: encrypted,
     };
     const signed = await signer.signEvent(template);
+    // Durable copy so a write made while the store is empty has something to
+    // fall back on.
+    try {
+      if (user) {
+        localStorage.setItem(
+          `pollerama:bookmarks:${user.pubkey}`,
+          JSON.stringify(signed),
+        );
+      }
+    } catch {
+      // best-effort persistence
+    }
     await dataLayer.publishEvent(signed);
     return signed;
   };
@@ -439,12 +558,14 @@ export function ListProvider({ children }: { children: ReactNode }) {
   const bookmarkFollowPack = async (packEvent: Event): Promise<void> => {
     const identifier = packEvent.tags.find((t) => t[0] === "d")?.[1] || "";
     const adref = `39089:${packEvent.pubkey}:${identifier}`;
-    const current = Array.from(bookmarkedPackKeys);
-    if (current.includes(adref)) return;
-    const newAdrefs = [...current, adref];
-    const signed = await buildAndPublishBookmarks(newAdrefs);
+    if (bookmarkedPackKeys.has(adref)) return;
+    const newAdrefs = [...Array.from(bookmarkedPackKeys), adref];
+    const signed = await buildAndPublishBookmarks(
+      newAdrefs,
+      Array.from(bookmarkedEventRefs),
+    );
     setBookmarks10003(signed);
-    setBookmarkedPackKeys(new Set(newAdrefs));
+    setBookmarkedPackKeys(new Set(bookmarkedPackKeys).add(adref));
     handleListEvent(packEvent);
   };
 
@@ -452,9 +573,27 @@ export function ListProvider({ children }: { children: ReactNode }) {
     const identifier = packEvent.tags.find((t) => t[0] === "d")?.[1] || "";
     const adref = `39089:${packEvent.pubkey}:${identifier}`;
     const newAdrefs = Array.from(bookmarkedPackKeys).filter((k) => k !== adref);
-    const signed = await buildAndPublishBookmarks(newAdrefs);
+    const signed = await buildAndPublishBookmarks(newAdrefs, Array.from(bookmarkedEventRefs));
     setBookmarks10003(signed);
     setBookmarkedPackKeys(new Set(newAdrefs));
+  };
+
+  const bookmarkEvent = async (event: Event): Promise<void> => {
+    const ref = eventRefOf(event);
+    if (bookmarkedEventRefs.has(ref)) return;
+    const newRefs = [...Array.from(bookmarkedEventRefs), ref];
+    const signed = await buildAndPublishBookmarks(Array.from(bookmarkedPackKeys), newRefs);
+    setBookmarks10003(signed);
+    setBookmarkedEventRefs(new Set(bookmarkedEventRefs).add(ref));
+    if (event.kind === 39089) handleListEvent(event);
+  };
+
+  const unbookmarkEvent = async (event: Event): Promise<void> => {
+    const ref = eventRefOf(event);
+    const newRefs = Array.from(bookmarkedEventRefs).filter((r) => r !== ref);
+    const signed = await buildAndPublishBookmarks(Array.from(bookmarkedPackKeys), newRefs);
+    setBookmarks10003(signed);
+    setBookmarkedEventRefs(new Set(newRefs));
   };
 
   const subscribeToContacts = () => {
@@ -936,6 +1075,9 @@ export function ListProvider({ children }: { children: ReactNode }) {
         bookmarkedPackKeys,
         bookmarkFollowPack,
         unbookmarkFollowPack,
+        bookmarkedEventRefs,
+        bookmarkEvent,
+        unbookmarkEvent,
         fetchAndHydratePacks,
         getNetworkFollowers,
         getTrustScore,

--- a/src/contexts/lists-context.tsx
+++ b/src/contexts/lists-context.tsx
@@ -104,26 +104,34 @@ function migrateLegacyWotCache(pubkey: string): WotCacheRecord | null {
   return record;
 }
 
-// NIP-22 ref for a bookmarkable event: addressable kinds (d-tagged long-form)
-// use their canonical "kind:pubkey:identifier", everything else falls back to
-// the event id so the bookmark stays resolvable.
+// Ref for a bookmarkable event, in NIP-51 shape: addressable kinds (d-tagged,
+// parameterized-replaceable range) use the canonical "kind:pubkey:identifier"
+// a-ref, everything else (notes, polls, …) uses the bare event id — which the
+// list stores as an `e` tag. Other NIP-51 clients resolve both forms.
 export function eventRefOf(event: Event) {
-  if (event.kind >= 30000 && event.tags.some((t) => t[0] === "d")) {
+  if (event.kind >= 30000 && event.kind < 40000 && event.tags.some((t) => t[0] === "d")) {
     return `${event.kind}:${event.pubkey}:${event.tags.find((t) => t[0] === "d")![1]}`;
   }
-  return `${event.kind}:${event.pubkey}:${event.id}`;
+  return event.id;
 }
 
-// Heuristic for a public `a` tag that is one of OUR event bookmarks (as opposed
-// to foreign NIP-53 a-tags we must preserve). Our refs carry a third segment:
-// either a d-identifier (addressable kinds) or a full 64-hex event id
-// (non-addressable kinds). Short 2-segment a-tags are ambiguous with other kinds
-// of a-style references and stay untouched either way.
-function isEventRef(ref: string) {
-  const parts = ref.split(":");
-  if (parts.length < 3) return false;
-  return /^39089$/.test(parts[0]) ? parts.length > 3 : !!parts[2];
-}
+// Refs written by earlier versions of this client always used a-tags of the
+// form `kind:pubkey:<event-id>` — but only for non-addressable kinds; for
+// addressable kinds the third segment was always the real d-identifier, so
+// those a-refs were already canonical and must be preserved as-is.
+const HEX64 = /^[0-9a-f]{64}$/i;
+const LEGACY_A_REF = /^(\d+):[0-9a-f]{64}:([0-9a-f]{64})$/i;
+
+// Legacy plain-event a-refs collapse to their event id (stored as `e` going
+// forward); addressable-kind a-refs and anything unrecognized pass through.
+export const normalizeBookmarkRef = (ref: string): string => {
+  const m = ref.match(LEGACY_A_REF);
+  if (!m) return ref;
+  const kind = Number(m[1]);
+  // Parameterized-replaceable range: the third segment is a real identifier.
+  if (kind >= 30000 && kind < 40000) return ref;
+  return m[2];
+};
 
 interface ListContextInterface {
   lists: Map<string, Event> | undefined;
@@ -148,8 +156,9 @@ interface ListContextInterface {
   bookmarkedPackKeys: Set<string>;
   bookmarkFollowPack: (packEvent: Event) => Promise<void>;
   unbookmarkFollowPack: (packEvent: Event) => Promise<void>;
-  // NIP-53 bookmarks of arbitrary events (notes, polls, articles, …), stored as
-  // public `a` tags on the kind-10003 event.
+  // NIP-51 bookmarks of arbitrary events (notes, polls, articles, …), stored
+  // as public `e` tags (plain events) and canonical `a` refs (addressable
+  // kinds) on the kind-10003 event.
   bookmarkedEventRefs: Set<string>;
   bookmarkEvent: (event: Event) => Promise<void>;
   unbookmarkEvent: (event: Event) => Promise<void>;
@@ -416,10 +425,18 @@ export function ListProvider({ children }: { children: ReactNode }) {
       }
     }
 
-    // Also read any unencrypted public tags (backwards compat)
-    const aTags = event.tags.filter((t) => t[0] === "a" && t[1]);
-    const publicAdrefs = aTags.filter((t) => t[1].startsWith("39089:")).map((t) => t[1]);
-    eventRefs.push(...aTags.filter((t) => !t[1].startsWith("39089:")).map((t) => t[1]));
+    // Also read any unencrypted public tags. Current format: `e` tags for
+    // plain events, canonical a-refs for addressable kinds. Legacy refs
+    // (`kind:pubkey:<event-id>` a-tags from earlier builds) normalize to
+    // their event id; foreign NIP-51 addressable a-refs pass through.
+    const aTags = event.tags.filter((t) => (t[0] === "a" || t[0] === "e") && t[1]);
+    const publicAdrefs = aTags.filter((t) => t[0] === "a" && t[1].startsWith("39089:")).map((t) => t[1]);
+    eventRefs.push(
+      ...aTags
+        .filter((t) => t[0] === "a" && !t[1].startsWith("39089:"))
+        .map((t) => normalizeBookmarkRef(t[1])),
+    );
+    eventRefs.push(...aTags.filter((t) => t[0] === "e").map((t) => t[1]));
     const allAdrefs = Array.from(new Set([...adrefs, ...publicAdrefs]));
     const allEventRefs = Array.from(new Set(eventRefs));
 
@@ -465,13 +482,22 @@ export function ListProvider({ children }: { children: ReactNode }) {
     }
   };
 
-  // Re-merge a fresher list with whatever the UI already holds. Covers a
-  // bookmark added from another client (its ref would otherwise be dropped),
-  // while leaving a genuinely empty existing list empty.
+  // Re-merge a fresher list with the current sets, then apply a delta. Reads
+  // BOTH ref spellings we may find on disk: the current format (e-tags for
+  // plain events, a-refs for addressable kinds) and legacy a-refs
+  // (`kind:pubkey:<event-id>` written by earlier versions), which normalize to
+  // plain event ids here — so the migration to NIP-51 tags happens on the next
+  // publish without losing anything.
+  interface BookmarkDelta {
+    addRefs?: string[];
+    removeRefs?: string[];
+    addPacks?: string[];
+    removePacks?: string[];
+  }
+
   const mergeBookmarks = async (
     existing: Event | null,
-    packs: string[],
-    refs: string[],
+    delta: BookmarkDelta = {},
   ): Promise<{ packAdrefs: string[]; eventRefs: string[] }> => {
     let existingPacks: string[] = [];
     if (existing?.content) {
@@ -488,26 +514,48 @@ export function ListProvider({ children }: { children: ReactNode }) {
         // Fall back to public tags below
       }
     }
-    const aTags = (existing?.tags ?? []).filter((t) => t[0] === "a" && t[1]);
+    const aTags = (existing?.tags ?? []).filter((t) => (t[0] === "a" || t[0] === "e") && t[1]);
     existingPacks = Array.from(
       new Set([
         ...existingPacks,
-        ...aTags.filter((t) => t[1].startsWith("39089:")).map((t) => t[1]),
+        ...aTags.filter((t) => t[0] === "a" && t[1].startsWith("39089:")).map((t) => t[1]),
       ]),
     );
     const existingRefs = Array.from(
-      new Set(aTags.filter((t) => !t[1].startsWith("39089:")).map((t) => t[1])),
+      new Set([
+        // Legacy event a-refs normalize to their event id; foreign addressable
+        // a-refs (and anything unrecognized) pass through untouched.
+        ...aTags
+          .filter((t) => t[0] === "a" && !t[1].startsWith("39089:"))
+          .map((t) => normalizeBookmarkRef(t[1])),
+        // Plain-event bookmarks, ours (current format) and other NIP-51 clients'.
+        ...aTags.filter((t) => t[0] === "e").map((t) => t[1]),
+      ]),
     );
-    return {
-      packAdrefs: Array.from(new Set([...existingPacks, ...packs])),
-      eventRefs: Array.from(new Set([...existingRefs, ...refs])),
-    };
+    let packAdrefs = Array.from(new Set([...existingPacks, ...(delta.addPacks ?? [])]));
+    let eventRefs = Array.from(new Set([...existingRefs, ...(delta.addRefs ?? [])]));
+    if (delta.removePacks?.length) packAdrefs = packAdrefs.filter((p) => !delta.removePacks!.includes(p));
+    if (delta.removeRefs?.length) eventRefs = eventRefs.filter((r) => !delta.removeRefs!.includes(r));
+    return { packAdrefs, eventRefs };
   };
 
+  // Every kind-10003 publication runs through this queue: each mutation
+  // re-fetches the freshest list and applies its delta, so rapid toggles or
+  // racing pack/event updates can never interleave read-modify-write cycles
+  // and drop each other's changes.
+  const bookmarkMutationQueue = useRef<Promise<unknown>>(Promise.resolve());
+  const enqueueBookmarkMutation = useCallback(
+    <T,>(fn: () => Promise<T>): Promise<T> => {
+      const next = bookmarkMutationQueue.current.then(fn, fn);
+      bookmarkMutationQueue.current = next.catch(() => undefined);
+      return next;
+    },
+    [],
+  );
+
   const buildAndPublishBookmarks = async (
-    packAdrefs: string[],
-    eventRefs: string[] = [],
-  ): Promise<Event> => {
+    delta: BookmarkDelta = {},
+  ): Promise<{ signed: Event; refs: string[]; packs: string[] }> => {
     // Never build on top of nothing when we know a real list exists: the
     // initial fetch can resolve empty after a network error (or the account-
     // reset effect clears the state), and a lone bookmark would then clobber
@@ -515,19 +563,30 @@ export function ListProvider({ children }: { children: ReactNode }) {
     // followPubkey contacts-list pattern.
     const latest = await fetchLatestBookmarks();
     const fresh = latest ?? bookmarks10003;
-    const merged = await mergeBookmarks(fresh, packAdrefs, eventRefs);
+    const merged = await mergeBookmarks(fresh, delta);
 
     const signer = await signerManager.getSigner();
     const pubkey = await signer.getPublicKey();
     const privateTags = merged.packAdrefs.map((a) => ["a", a]);
     const encrypted = await signer.nip44Encrypt!(pubkey, JSON.stringify(privateTags));
 
-    // Preserve all existing public tags except our own 39089 a-tags (which are
-    // now private) and our own event refs (rebuilt from `eventRefs`). Other
-    // clients' a-tags (foreign NIP-53 bookmarks) are kept untouched.
-    const foreignTags = (fresh?.tags ?? []).filter(
-      (t) => !(t[0] === "a" && (t[1]?.startsWith("39089:") || isEventRef(t[1] ?? ""))),
-    );
+    // NIP-51 tag spelling: plain events go out as `e` tags, addressable kinds
+    // as canonical a-refs. Tags that are neither of ours (d, title, … on
+    // curated sets) are carried over untouched.
+    const otherTags = (fresh?.tags ?? []).filter((t) => t[0] !== "a" && t[0] !== "e");
+    const refTags = merged.eventRefs.map((r) => (HEX64.test(r) ? ["e", r] : ["a", r]));
+
+    // Skip the publish entirely when the delta changes nothing — a redundant
+    // toggle would otherwise bump created_at and re-broadcast the same list.
+    // (`before` is the merged state with an empty delta, i.e. the normalized
+    // current list; identical lengths + sets ⇒ nothing to write.)
+    const before = await mergeBookmarks(fresh);
+    const same =
+      before.eventRefs.length === merged.eventRefs.length &&
+      before.packAdrefs.length === merged.packAdrefs.length;
+    if (same && fresh) {
+      return { signed: fresh, refs: merged.eventRefs, packs: merged.packAdrefs };
+    }
 
     // Strictly newer than both wall-clock and any known existing list, so the
     // published event wins over the older one on relay ordering.
@@ -535,7 +594,7 @@ export function ListProvider({ children }: { children: ReactNode }) {
     const template: EventTemplate = {
       kind: 10003,
       created_at: Math.max(Math.floor(Date.now() / 1000), baseTs + 1),
-      tags: [...foreignTags, ...merged.eventRefs.map((r) => ["a", r])],
+      tags: [...otherTags, ...refTags],
       content: encrypted,
     };
     const signed = await signer.signEvent(template);
@@ -552,48 +611,50 @@ export function ListProvider({ children }: { children: ReactNode }) {
       // best-effort persistence
     }
     await dataLayer.publishEvent(signed);
-    return signed;
+    return { signed, refs: merged.eventRefs, packs: merged.packAdrefs };
   };
 
-  const bookmarkFollowPack = async (packEvent: Event): Promise<void> => {
+  // All four mutations run through enqueueBookmarkMutation so concurrent calls
+  // serialize; each one's merge re-reads the freshest list, so nothing is lost.
+  const bookmarkFollowPack = (packEvent: Event): Promise<void> => {
     const identifier = packEvent.tags.find((t) => t[0] === "d")?.[1] || "";
     const adref = `39089:${packEvent.pubkey}:${identifier}`;
-    if (bookmarkedPackKeys.has(adref)) return;
-    const newAdrefs = [...Array.from(bookmarkedPackKeys), adref];
-    const signed = await buildAndPublishBookmarks(
-      newAdrefs,
-      Array.from(bookmarkedEventRefs),
-    );
-    setBookmarks10003(signed);
-    setBookmarkedPackKeys(new Set(bookmarkedPackKeys).add(adref));
-    handleListEvent(packEvent);
+    if (!adref || adref === "39089:") return Promise.resolve();
+    return enqueueBookmarkMutation(async () => {
+      const { signed, packs } = await buildAndPublishBookmarks({ addPacks: [adref] });
+      setBookmarks10003(signed);
+      setBookmarkedPackKeys(new Set(packs));
+      handleListEvent(packEvent);
+    });
   };
 
-  const unbookmarkFollowPack = async (packEvent: Event): Promise<void> => {
+  const unbookmarkFollowPack = (packEvent: Event): Promise<void> => {
     const identifier = packEvent.tags.find((t) => t[0] === "d")?.[1] || "";
     const adref = `39089:${packEvent.pubkey}:${identifier}`;
-    const newAdrefs = Array.from(bookmarkedPackKeys).filter((k) => k !== adref);
-    const signed = await buildAndPublishBookmarks(newAdrefs, Array.from(bookmarkedEventRefs));
-    setBookmarks10003(signed);
-    setBookmarkedPackKeys(new Set(newAdrefs));
+    return enqueueBookmarkMutation(async () => {
+      const { signed, packs } = await buildAndPublishBookmarks({ removePacks: [adref] });
+      setBookmarks10003(signed);
+      setBookmarkedPackKeys(new Set(packs));
+    });
   };
 
-  const bookmarkEvent = async (event: Event): Promise<void> => {
+  const bookmarkEvent = (event: Event): Promise<void> => {
     const ref = eventRefOf(event);
-    if (bookmarkedEventRefs.has(ref)) return;
-    const newRefs = [...Array.from(bookmarkedEventRefs), ref];
-    const signed = await buildAndPublishBookmarks(Array.from(bookmarkedPackKeys), newRefs);
-    setBookmarks10003(signed);
-    setBookmarkedEventRefs(new Set(bookmarkedEventRefs).add(ref));
-    if (event.kind === 39089) handleListEvent(event);
+    return enqueueBookmarkMutation(async () => {
+      const { signed, refs } = await buildAndPublishBookmarks({ addRefs: [ref] });
+      setBookmarks10003(signed);
+      setBookmarkedEventRefs(new Set(refs));
+      if (event.kind === 39089) handleListEvent(event);
+    });
   };
 
-  const unbookmarkEvent = async (event: Event): Promise<void> => {
+  const unbookmarkEvent = (event: Event): Promise<void> => {
     const ref = eventRefOf(event);
-    const newRefs = Array.from(bookmarkedEventRefs).filter((r) => r !== ref);
-    const signed = await buildAndPublishBookmarks(Array.from(bookmarkedPackKeys), newRefs);
-    setBookmarks10003(signed);
-    setBookmarkedEventRefs(new Set(newRefs));
+    return enqueueBookmarkMutation(async () => {
+      const { signed, refs } = await buildAndPublishBookmarks({ removeRefs: [ref] });
+      setBookmarks10003(signed);
+      setBookmarkedEventRefs(new Set(refs));
+    });
   };
 
   const subscribeToContacts = () => {

--- a/src/hooks/useListContext.tsx
+++ b/src/hooks/useListContext.tsx
@@ -1,5 +1,7 @@
 import { useContext } from "react";
-import { ListContext } from "../contexts/lists-context";
+import { ListContext, eventRefOf } from "../contexts/lists-context";
+
+export { eventRefOf };
 
 export function useListContext() {
   const context = useContext(ListContext);


### PR DESCRIPTION
Adds a Bookmarks feed, a BookmarkButton in the feedback menu, and event ref bookmarking (NIP-53 style) alongside the existing private pack bookmarks in lists-context. Includes sign_event:10003 in the NostrConnect perms and wires the feed into App routes and SidePane.

Guards the write path against clobbering an existing bookmark list when the initial fetch resolves empty after a network error: the publisher now re-fetches the latest list (with a durable fallback), merges the delta into it, and stamps it strictly newer before publishing — the same defensive pattern as followPubkey.

Fixes: an empty in-memory bookmark event caused bookmarking a single event to overwrite the user's full list.