### PR TITLE
Add private mute list and WoT-only content filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 1.16.0
+
+- Bookmarks: save any note, poll, or article with the bookmark button and find them later on the new Bookmarks page (under the profile menu). Bookmarked follow packs are supported too, and bookmark counts show how many people saved the same thing.
+- Mute: mute anyone from the ⋯ menu on a note, comment, or poll (or unmute them from Moderation settings). Muted accounts never trigger notifications and are hidden from comments and likes. Your mute list is private — stored encrypted, readable only by you — and syncs across your devices.
+- Web of Trust filters: new Moderation settings let you restrict comments, likes, and notifications to people in your Web of Trust only. Notifications can be filtered separately for the in-app list and for background push. Outside content isn't even fetched for those surfaces where possible, and the Android background notifier applies the same filter using an efficient compact filter.
+- Larger web of trust (optional): a new "Expand to 2 degrees" switch in Network settings also pulls the contact lists of your friends-of-friends (top 2,000 by trust), making the network — and the filters above — much more complete. Off by default; applies on the next recompute.
+- Fixed a render leak in Moderation settings that stacked listeners on every revisit.
+
 # 1.15.0
 
 - Games: a new Games section with three daily puzzles — 2048, Tetris and a racer. Everyone plays the exact same board and piece sequence for the day, Wordle-style, and you can play offline. Post your run to a daily leaderboard — there's no score-keeping server, so each run records your inputs and anyone can re-play them to verify the score, making the board provably fair.

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "com.formstr.pollerama"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 89
-        versionName "1.15.1"
+        versionCode 90
+        versionName "1.16.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/android/app/src/main/java/com/formstr/pollerama/NotificationWorker.java
+++ b/android/app/src/main/java/com/formstr/pollerama/NotificationWorker.java
@@ -7,6 +7,7 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.net.Uri;
 import android.os.Build;
+import android.util.Base64;
 import androidx.annotation.NonNull;
 import androidx.core.app.NotificationCompat;
 import androidx.work.Worker;
@@ -45,6 +46,8 @@ public class NotificationWorker extends Worker {
     private static final String KEY_LAST      = "worker_last_check";
     private static final String KEY_PENDING   = "notif_pending_ids";
     private static final String KEY_SEEN_DMS  = "worker_seen_dm_ids";
+    private static final String KEY_MUTED     = "worker_muted";
+    private static final String KEY_WOT_ONLY  = "worker_wot_only_notifs";
     private static final String EVENT_KEY_PREFIX = "notif_event_";
     private static final int    NOTIF_DMS     = 1002;
     private static final long   TIMEOUT_SEC   = 15;
@@ -106,6 +109,22 @@ public class NotificationWorker extends Worker {
             String name = profilesObj.optString(pk, null);
             if (name != null && !name.isEmpty()) profileNames.put(pk, name);
         }
+
+        // Moderation gates, bridged from the JS layer (see useAndroidNotifications):
+        //  - muted authors never notify (nor persist to the in-app queue).
+        //  - when the WoT-only-notifications toggle is on, only WoT members
+        //    notify. The WoT set crosses as a bloom filter (it can hold
+        //    100k+ pubkeys at 2nd degree; a JSON array would be a multi-MB
+        //    prefs blob). False positives = at most one stray OS notification;
+        //    the in-app list re-filters with the exact set on drain.
+        final Set<String> muted = new HashSet<>();
+        JSONArray mutedArr = parseJsonArray(prefs.getString(KEY_MUTED, "[]"));
+        for (int i = 0; i < mutedArr.length(); i++) {
+            String pk = mutedArr.optString(i, null);
+            if (pk != null && !pk.isEmpty()) muted.add(pk);
+        }
+        JSONObject wotOnlyObj = parseJsonObject(prefs.getString(KEY_WOT_ONLY, "{}"));
+        final BloomFilter wotBloom = BloomFilter.fromJson(wotOnlyObj);
 
         long lastCheck = prefs.getLong(KEY_LAST, System.currentTimeMillis() / 1000 - 3600);
         long nowSec    = System.currentTimeMillis() / 1000;
@@ -197,6 +216,12 @@ public class NotificationWorker extends Worker {
                             int kind = event.getInt("kind");
                             // Skip events authored by any of my accounts (won't notify yourself)
                             if (myPubkeys.contains(event.optString("pubkey"))) return;
+                            // Moderation gates: muted authors and (when the
+                            // WoT-only toggle is on) non-WoT authors are
+                            // dropped before dedup/persist/post.
+                            final String author = event.optString("pubkey");
+                            if (muted.contains(author)) return;
+                            if (wotBloom.enabled && !wotBloom.mightContain(author)) return;
                             if (kind == 1059) {
                                 dms.add(event);
                             } else {
@@ -539,5 +564,90 @@ public class NotificationWorker extends Worker {
         String name = profileNames.get(pubkey);
         if (name != null && !name.isEmpty()) return name;
         return pubkey != null && pubkey.length() >= 8 ? pubkey.substring(0, 8) + "…" : "Someone";
+    }
+
+    /**
+     * Bloom filter over the bridged web-of-trust set. The bit layout MUST match
+     * src/utils/wotBloom.ts exactly (frozen wire format v1):
+     *   m = bits (power of two), k = 11 probes, big-endian u32 slices of the raw
+     *   hex pubkey bytes: h1 = bytes[0..4], h2 = bytes[4..8], idx_i = (h1 + i*h2) mod m,
+     *   bit set at (idx >>> 3) high-to-low: 1 << (idx & 7).
+     * No cryptographic hash — both sides read the same 64 bits off the raw key,
+     * so there is no library-parity risk.
+     */
+    private static final class BloomFilter {
+        final boolean enabled;
+        private final int bits;
+        private final byte[] data;
+
+        private BloomFilter(boolean enabled, int bits, byte[] data) {
+            this.enabled = enabled;
+            this.bits = bits;
+            this.data = data;
+        }
+
+        /** Parse {enabled, bits, data(base64)} bridged from JS. Enabled only
+         * when a usable filter is present (enabled-but-empty falls back to
+         * notifying; the app re-filters on drain). */
+        static BloomFilter fromJson(JSONObject obj) {
+            if (obj == null || !obj.optBoolean("enabled", false)) return disabled();
+            int bits = obj.optInt("bits", 0);
+            String b64 = obj.optString("data", null);
+            if (bits < 1024 || bits % 8 != 0 || b64 == null || b64.isEmpty()) {
+                return disabled();
+            }
+            try {
+                byte[] raw = Base64.decode(b64, Base64.NO_WRAP);
+                if (raw.length != bits / 8) return disabled();
+                return new BloomFilter(true, bits, raw);
+            } catch (Exception e) {
+                return disabled();
+            }
+        }
+
+        static BloomFilter disabled() {
+            return new BloomFilter(false, 0, null);
+        }
+
+        boolean mightContain(String hexPubkey) {
+            if (!enabled || hexPubkey == null || hexPubkey.length() < 16) return !enabled;
+            long h1 = fmix32((int) u32be(hexPubkey, 0));
+            long h2 = fmix32((int) u32be(hexPubkey, 4)) | 1L;
+            for (int i = 0; i < 11; i++) {
+                long idx = (h1 + (long) i * h2) % bits;
+                int bit = (int) (idx & 7);
+                int byi = (int) (idx >>> 3);
+                if ((data[byi] & (1 << bit)) == 0) return false;
+            }
+            return true;
+        }
+
+        /** MurmurHash3 32-bit finalizer — MUST match wotBloom.ts fmix32 (frozen
+         * wire format v1). */
+        private static long fmix32(int h) {
+            int x = h;
+            x ^= x >>> 16;
+            x *= 0x85ebca6b;
+            x ^= x >>> 13;
+            x *= 0xc2b2ae35;
+            x ^= x >>> 16;
+            return x & 0xFFFFFFFFL;
+        }
+
+        /** Big-endian u32 from hex chars [off*2, off*2+8). Hex-decode-free: reads
+         * the same bytes the JS side decodes into its Uint8Array. */
+        private static long u32be(String hex, int off) {
+            int v = 0;
+            for (int i = 0; i < 4; i++) {
+                v = (v << 8) | hexPair(hex, off * 2 + i * 2);
+            }
+            return v & 0xFFFFFFFFL;
+        }
+
+        private static int hexPair(String hex, int off) {
+            int hi = Character.digit(hex.charAt(off), 16);
+            int lo = Character.digit(hex.charAt(off + 1), 16);
+            return (hi << 4) | lo;
+        }
     }
 }

--- a/android/app/src/main/java/com/formstr/pollerama/NotificationWorker.java
+++ b/android/app/src/main/java/com/formstr/pollerama/NotificationWorker.java
@@ -569,8 +569,10 @@ public class NotificationWorker extends Worker {
     /**
      * Bloom filter over the bridged web-of-trust set. The bit layout MUST match
      * src/utils/wotBloom.ts exactly (frozen wire format v1):
-     *   m = bits (power of two), k = 11 probes, big-endian u32 slices of the raw
-     *   hex pubkey bytes: h1 = bytes[0..4], h2 = bytes[4..8], idx_i = (h1 + i*h2) mod m,
+     *   m = bits (byte-aligned; NOT required to be a power of two — both sides
+     *   use true modulo), k = 11 probes, big-endian u32 slices of the raw
+     *   hex pubkey bytes: h1 = bytes[0..4], h2 = bytes[4..8], each passed
+     *   through MurmurHash3's fmix32, h2 forced odd, idx_i = (h1 + i*h2) mod m,
      *   bit set at (idx >>> 3) high-to-low: 1 << (idx & 7).
      * No cryptographic hash — both sides read the same 64 bits off the raw key,
      * so there is no library-parity risk.

--- a/package.json
+++ b/package.json
@@ -51,6 +51,22 @@
     "eject": "react-scripts eject"
   },
   "jest": {
+    "transform": {
+      "^.+\\.(t|j)sx?$": [
+        "babel-jest",
+        {
+          "presets": [
+            "@babel/preset-env",
+            [
+              "@babel/preset-typescript",
+              {
+                "allowDeclareFields": true
+              }
+            ]
+          ]
+        }
+      ]
+    },
     "moduleNameMapper": {
       "^nostr-tools/nip46$": "<rootDir>/node_modules/nostr-tools/lib/cjs/nip46.js",
       "^nostr-tools/nip49$": "<rootDir>/node_modules/nostr-tools/lib/cjs/nip49.js",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,6 +34,7 @@ import { RelayHealthProvider } from "./contexts/RelayHealthContext";
 import { NostrNotificationsProvider } from "./contexts/nostr-notification-context";
 import { DMProvider } from "./contexts/dm-context";
 import { ReportsProvider } from "./contexts/reports-context";
+import { ModerationProvider } from "./contexts/moderation-context";
 import { TranslationBatchProvider } from "./contexts/translation-batch-context";
 import { FeedScrollProvider } from "./contexts/FeedScrollContext";
 import { SubNavProvider } from "./contexts/SubNavContext";
@@ -338,6 +339,7 @@ const App: React.FC = () => {
         <DynamicThemeWrapper>
           <AppContextProvider>
             <UserProvider>
+              <ModerationProvider>
               <DataLayerScopeBridge>
               <RelayProvider>
                 <RelayHealthProvider>
@@ -380,6 +382,7 @@ const App: React.FC = () => {
                 </RelayHealthProvider>
               </RelayProvider>
               </DataLayerScopeBridge>
+              </ModerationProvider>
             </UserProvider>
           </AppContextProvider>
         </DynamicThemeWrapper>

--- a/src/components/Common/Comments/CommentSection.tsx
+++ b/src/components/Common/Comments/CommentSection.tsx
@@ -34,6 +34,8 @@ import CommentInput from "./CommentInput";
 import { extractMentionTags } from '../../EventCreator/MentionTextArea';
 import { getColorsWithTheme } from "../../../styles/theme";
 import { useNotification } from "../../../contexts/notification-context";
+import { useModeration } from "../../../contexts/moderation-context";
+import VisibilityOffIcon from "@mui/icons-material/VisibilityOff";
 import { dataLayer, type ObserveHandle } from "@formstr/local-relay";
 import { usePublishDiagnostic } from "../../../hooks/usePublishDiagnostic";
 import { PublishDiagnosticModal } from "../PublishDiagnosticModal";
@@ -99,6 +101,7 @@ const CommentCard: React.FC<CommentCardProps> = ({ comment, depth, commentAncest
   const { showNotification } = useNotification();
   const eventRelays = useEventRelays(comment.id);
   const { reportEvent, reportUser } = useReports();
+  const { isMuted, mutePubkey, unmutePubkey } = useModeration();
   const navigate = useNavigate();
 
   const [menuAnchor, setMenuAnchor] = useState<null | HTMLElement>(null);
@@ -284,6 +287,18 @@ const CommentCard: React.FC<CommentCardProps> = ({ comment, depth, commentAncest
           <MenuItem onClick={() => { setMenuAnchor(null); setReportUserOpen(true); }} sx={{ color: "error.main" }}>
             <FlagIcon fontSize="small" sx={{ mr: 1 }} />
             Report user
+          </MenuItem>
+        )}
+        {user && !isOwnComment && (
+          <MenuItem
+            onClick={() => {
+              setMenuAnchor(null);
+              if (isMuted(comment.pubkey)) unmutePubkey(comment.pubkey);
+              else mutePubkey(comment.pubkey);
+            }}
+          >
+            <VisibilityOffIcon fontSize="small" sx={{ mr: 1 }} />
+            {isMuted(comment.pubkey) ? "Unmute user" : "Mute user"}
           </MenuItem>
         )}
       </Menu>

--- a/src/components/FeedbackMenu/index.tsx
+++ b/src/components/FeedbackMenu/index.tsx
@@ -107,7 +107,7 @@ export const FeedbackMenu: React.FC<FeedbackMenuProps> = ({
             onScroll={handleScroll}
             display="flex"
             alignItems="center"
-            gap={1.25}
+            gap={2}
             sx={{
               overflowX: "auto",
               WebkitOverflowScrolling: "touch",

--- a/src/components/Header/ModerationSettings.tsx
+++ b/src/components/Header/ModerationSettings.tsx
@@ -1,8 +1,52 @@
-import { Box, Slider, Typography } from "@mui/material";
+import { useState } from "react";
+import {
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Divider,
+  FormControlLabel,
+  List,
+  ListItem,
+  ListItemText,
+  Slider,
+  Switch,
+  Typography,
+} from "@mui/material";
 import { useReports } from "../../hooks/useReports";
+import { useModeration } from "../../contexts/moderation-context";
+import { contentPolicy, WotScope, MAX_FILTER_AUTHORS } from "../../utils/contentPolicy";
+import { nip19 } from "nostr-tools";
 
 export function ModerationSettings() {
   const { wotReportThreshold, setWotReportThreshold } = useReports();
+  const { mutedPubkeys, unmutePubkey, isLoading, wotOnly, setWotOnly } = useModeration();
+  const [mutedVersion, setMutedVersion] = useState(0);
+  // Re-render on any policy change (WoT size affects toggle helper text).
+  contentPolicy.subscribe(() => setMutedVersion((v) => v + 1));
+
+  const wotSize = contentPolicy.getWoTSize();
+
+  const toggles: { scope: WotScope; label: string; description: string }[] = [
+    {
+      scope: "notifs",
+      label: "Notifications",
+      description:
+        "Only receive notifications (in-app and background push) from people in your Web of Trust. Muted users are always filtered.",
+    },
+    {
+      scope: "comments",
+      label: "Comments",
+      description:
+        "Only fetch and show comments from people in your Web of Trust.",
+    },
+    {
+      scope: "likes",
+      label: "Likes",
+      description:
+        "Only fetch and show likes/reactions from people in your Web of Trust.",
+    },
+  ];
 
   return (
     <Box>
@@ -40,6 +84,104 @@ export function ModerationSettings() {
           choose to reveal hidden items individually.
         </Typography>
       </Box>
+
+      <Divider sx={{ my: 4 }} />
+
+      {/* ── WoT-only per-surface toggles ─────────────────────────────── */}
+      <Typography variant="subtitle1" gutterBottom>
+        Web of Trust only
+      </Typography>
+      <Typography variant="body2" color="text.secondary" gutterBottom>
+        When enabled, content outside your Web of Trust (people you follow and
+        their follows) is not even fetched for that surface — filtered on the
+        wire where possible, at ingest otherwise.
+        {wotSize > MAX_FILTER_AUTHORS &&
+          " Your Web of Trust is large, so notifications are filtered on arrival rather than at fetch time."}
+        {wotSize === 0 &&
+          " Still computing your Web of Trust — filtering starts once it's ready."}
+      </Typography>
+
+      <Box sx={{ mt: 2 }}>
+        {toggles.map(({ scope, label, description }) => (
+          <Box key={scope} sx={{ mb: 2, maxWidth: 480 }}>
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={wotOnly[scope]}
+                  onChange={(e) => setWotOnly(scope, e.target.checked)}
+                />
+              }
+              label={
+                <Box>
+                  <Typography variant="body1">{label}</Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    {description}
+                  </Typography>
+                </Box>
+              }
+              sx={{ alignItems: "flex-start", m: 0 }}
+            />
+          </Box>
+        ))}
+      </Box>
+
+      <Divider sx={{ my: 4 }} />
+
+      {/* ── Muted users ──────────────────────────────────────────────── */}
+      <Typography variant="subtitle1" gutterBottom>
+        Muted users
+      </Typography>
+      <Typography variant="body2" color="text.secondary" gutterBottom>
+        Muted users never trigger notifications and are hidden from comments
+        and likes. Your mute list is private — it is stored encrypted and only
+        readable by you. Available on this device{mutedPubkeys.size > 0 ? ` (${mutedPubkeys.size})` : ""}.
+      </Typography>
+
+      {isLoading ? (
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1, mt: 2 }}>
+          <CircularProgress size={18} />
+          <Typography variant="body2" color="text.secondary">
+            Loading mute list…
+          </Typography>
+        </Box>
+      ) : mutedPubkeys.size === 0 ? (
+        <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+          Nobody is muted. Use the ⋯ menu on any note, comment, or poll to mute
+          its author.
+        </Typography>
+      ) : (
+        <List dense sx={{ maxWidth: 480 }}>
+          {Array.from(mutedPubkeys).map((pk) => (
+            <ListItem
+              key={pk}
+              secondaryAction={
+                <Button size="small" onClick={() => unmutePubkey(pk)}>
+                  Unmute
+                </Button>
+              }
+            >
+              <ListItemText
+                primary={shortNpub(pk)}
+                secondary={pk.slice(0, 16) + "…"}
+              />
+            </ListItem>
+          ))}
+        </List>
+      )}
+      <>{mutedVersion}</>
+      <Chip
+        size="small"
+        label="Muted list syncs across your devices (private to you)"
+        sx={{ mt: 1, display: mutedPubkeys.size > 0 ? "inline-flex" : "none" }}
+      />
     </Box>
   );
+}
+
+function shortNpub(pk: string): string {
+  try {
+    return nip19.npubEncode(pk).slice(0, 16) + "…";
+  } catch {
+    return pk.slice(0, 12) + "…";
+  }
 }

--- a/src/components/Header/ModerationSettings.tsx
+++ b/src/components/Header/ModerationSettings.tsx
@@ -1,8 +1,6 @@
-import { useState } from "react";
 import {
   Box,
   Button,
-  Chip,
   CircularProgress,
   Divider,
   FormControlLabel,
@@ -14,16 +12,17 @@ import {
   Typography,
 } from "@mui/material";
 import { useReports } from "../../hooks/useReports";
-import { useModeration } from "../../contexts/moderation-context";
+import { useModeration, useModerationVersion } from "../../contexts/moderation-context";
 import { contentPolicy, WotScope, MAX_FILTER_AUTHORS } from "../../utils/contentPolicy";
 import { nip19 } from "nostr-tools";
 
 export function ModerationSettings() {
   const { wotReportThreshold, setWotReportThreshold } = useReports();
   const { mutedPubkeys, unmutePubkey, isLoading, wotOnly, setWotOnly } = useModeration();
-  const [mutedVersion, setMutedVersion] = useState(0);
-  // Re-render on any policy change (WoT size affects toggle helper text).
-  contentPolicy.subscribe(() => setMutedVersion((v) => v + 1));
+  // Re-render on any policy change (WoT size affects toggle helper text, mute
+  // changes the list). useModerationVersion subscribes inside an effect; the
+  // version value itself is not used, only its change-firing.
+  useModerationVersion();
 
   const wotSize = contentPolicy.getWoTSize();
 
@@ -169,12 +168,6 @@ export function ModerationSettings() {
           ))}
         </List>
       )}
-      <>{mutedVersion}</>
-      <Chip
-        size="small"
-        label="Muted list syncs across your devices (private to you)"
-        sx={{ mt: 1, display: mutedPubkeys.size > 0 ? "inline-flex" : "none" }}
-      />
     </Box>
   );
 }

--- a/src/components/Header/ModerationSettings.tsx
+++ b/src/components/Header/ModerationSettings.tsx
@@ -28,10 +28,16 @@ export function ModerationSettings() {
 
   const toggles: { scope: WotScope; label: string; description: string }[] = [
     {
-      scope: "notifs",
-      label: "Notifications",
+      scope: "notifsForeground",
+      label: "Notifications — in-app",
       description:
-        "Only receive notifications (in-app and background push) from people in your Web of Trust. Muted users are always filtered.",
+        "Only show notifications in the in-app list from people in your Web of Trust.",
+    },
+    {
+      scope: "notifsBackground",
+      label: "Notifications — background push",
+      description:
+        "Only push OS notifications (while the app is closed or backgrounded) from people in your Web of Trust.",
     },
     {
       scope: "comments",

--- a/src/components/Header/ModerationSettings.tsx
+++ b/src/components/Header/ModerationSettings.tsx
@@ -94,11 +94,12 @@ export function ModerationSettings() {
       <Typography variant="body2" color="text.secondary" gutterBottom>
         When enabled, content outside your Web of Trust (people you follow and
         their follows) is not even fetched for that surface — filtered on the
-        wire where possible, at ingest otherwise.
+        wire where possible, at ingest otherwise. Muted users are always
+        filtered, regardless of these switches.
         {wotSize > MAX_FILTER_AUTHORS &&
           " Your Web of Trust is large, so notifications are filtered on arrival rather than at fetch time."}
         {wotSize === 0 &&
-          " Still computing your Web of Trust — filtering starts once it's ready."}
+          " Still computing your Web of Trust — while it's empty these switches have no effect (nothing is filtered)."}
       </Typography>
 
       <Box sx={{ mt: 2 }}>

--- a/src/components/Header/NetworkSettings.tsx
+++ b/src/components/Header/NetworkSettings.tsx
@@ -5,7 +5,9 @@ import {
   Chip,
   CircularProgress,
   Divider,
+  FormControlLabel,
   LinearProgress,
+  Switch,
   Tooltip,
   Typography,
 } from "@mui/material";
@@ -106,7 +108,7 @@ export const NetworkSettings: React.FC = () => {
   const [loading, setLoading] = React.useState(true);
   const [clearing, setClearing] = React.useState(false);
   const { user } = useUserContext();
-  const { isFetchingWoT, wotProfileCount, wotLastComputed, recomputeWebOfTrust } =
+  const { isFetchingWoT, wotProfileCount, wotLastComputed, recomputeWebOfTrust, wotTwoDegrees, setWotTwoDegrees } =
     useListContext();
   const wotSize = user?.webOfTrust?.size ?? 0;
 
@@ -260,6 +262,27 @@ export const NetworkSettings: React.FC = () => {
           Maps everyone the people you follow follow. Powers your network feed and
           content moderation; recomputed automatically every 5 days.
         </Typography>
+        <FormControlLabel
+          sx={{ mt: 1, alignItems: "flex-start" }}
+          control={
+            <Switch
+              checked={wotTwoDegrees}
+              onChange={(e) => setWotTwoDegrees(e.target.checked)}
+              disabled={isFetchingWoT || !user?.follows?.length}
+            />
+          }
+          label={
+            <Box>
+              <Typography variant="body2">Expand to 2 degrees</Typography>
+              <Typography variant="caption" color="text.secondary">
+                Also fetch the contact lists of your friends-of-friends (top
+                {` ${"2000"}`} by trust). Makes the network much larger — used by
+                the WoT-only filters and suggestions. Applies on the next compute;
+                the switch triggers one.
+              </Typography>
+            </Box>
+          }
+        />
       </Box>
 
       <Divider />

--- a/src/components/Notes/index.tsx
+++ b/src/components/Notes/index.tsx
@@ -46,6 +46,8 @@ import { useListContext } from "../../hooks/useListContext";
 import { dataLayer } from "@formstr/local-relay";
 import { useRelays } from "../../hooks/useRelays";
 import { useNotification } from "../../contexts/notification-context";
+import { useModeration } from "../../contexts/moderation-context";
+import VisibilityOffIcon from "@mui/icons-material/VisibilityOff";
 import { NOTIFICATION_MESSAGES } from "../../constants/notifications";
 import { aiService } from "../../services/ai-service";
 import { useReports } from "../../hooks/useReports";
@@ -136,6 +138,7 @@ export const Notes: React.FC<NotesProps> = ({
   const { showNotification } = useNotification();
 
   const { reportEvent, reportUser, isReportedByMe, getWoTReporters, wotReportThreshold, requestUserReportCheck } = useReports();
+  const { isMuted, mutePubkey, unmutePubkey } = useModeration();
   const [reportPostDialogOpen, setReportPostDialogOpen] = useState(false);
   const [reportUserDialogOpen, setReportUserDialogOpen] = useState(false);
   const [showReportedAnyway, setShowReportedAnyway] = useState(false);
@@ -635,6 +638,18 @@ export const Notes: React.FC<NotesProps> = ({
               >
                 <FlagIcon fontSize="small" sx={{ mr: 1 }} />
                 Report user
+              </MenuItem>
+            )}
+            {user && user.pubkey !== event.pubkey && (
+              <MenuItem
+                onClick={() => {
+                  handleCloseMenu();
+                  if (isMuted(event.pubkey)) unmutePubkey(event.pubkey);
+                  else mutePubkey(event.pubkey);
+                }}
+              >
+                <VisibilityOffIcon fontSize="small" sx={{ mr: 1 }} />
+                {isMuted(event.pubkey) ? "Unmute user" : "Mute user"}
               </MenuItem>
             )}
             {extras}

--- a/src/components/PollResponse/PollResponseForm.tsx
+++ b/src/components/PollResponse/PollResponseForm.tsx
@@ -49,6 +49,8 @@ import { useReports } from "../../hooks/useReports";
 import { ReportDialog } from "../Report/ReportDialog";
 import { ReportReason } from "../../contexts/reports-context";
 import FlagIcon from "@mui/icons-material/Flag";
+import VisibilityOffIcon from "@mui/icons-material/VisibilityOff";
+import { useModeration } from "../../contexts/moderation-context";
 import OverlappingAvatars from "../Common/OverlappingAvatars";
 import { Nip05Badge } from "../Common/Nip05Badge";
 import { RelaySourceModal } from "../Common/RelaySourceModal";
@@ -113,6 +115,7 @@ const PollResponseForm: React.FC<PollResponseFormProps> = ({
   const { relays } = useRelays();
   const { followPubkey } = useListContext();
   const { reportEvent, reportUser, isReportedByMe, getWoTReporters, wotReportThreshold, requestUserReportCheck } = useReports();
+  const { isMuted, mutePubkey, unmutePubkey } = useModeration();
   const eventRelays = useEventRelays(pollEvent.id);
   const handleCloseContactWarning = () => setShowContactListWarning(false);
   useBackClose(showContactListWarning, handleCloseContactWarning);
@@ -528,6 +531,19 @@ const PollResponseForm: React.FC<PollResponseFormProps> = ({
                 >
                   <FlagIcon fontSize="small" sx={{ mr: 1 }} />
                   Report author
+                </MenuItem>
+              )}
+              {user && user.pubkey !== pollEvent.pubkey && (
+                <MenuItem
+                  onClick={() => {
+                    setIsDetailsOpen(false);
+                    setAnchorEl(null);
+                    if (isMuted(pollEvent.pubkey)) unmutePubkey(pollEvent.pubkey);
+                    else mutePubkey(pollEvent.pubkey);
+                  }}
+                >
+                  <VisibilityOffIcon fontSize="small" sx={{ mr: 1 }} />
+                  {isMuted(pollEvent.pubkey) ? "Unmute user" : "Mute user"}
                 </MenuItem>
               )}
             </Menu>

--- a/src/contexts/app-context.tsx
+++ b/src/contexts/app-context.tsx
@@ -2,6 +2,7 @@ import { ReactNode, createContext, useRef, useState, useMemo, useCallback, useEf
 import { Event } from "nostr-tools/lib/types/core";
 import { Profile } from "../nostr/types";
 import { dataLayer, type Filter, type ObserveHandle } from "@formstr/local-relay";
+import { contentPolicy } from "../utils/contentPolicy";
 
 type AppContextInterface = {
   profiles: Map<string, Profile>;
@@ -75,6 +76,14 @@ export function AppContextProvider({ children }: { children: ReactNode }) {
   // optimistic removal (e.g. undoing a reaction) sticks even if the worker
   // re-streams the same event before the delete propagates.
   const deletedEventIds = useRef<Set<string>>(new Set());
+
+  // Active account pubkey for the moderation gates below. Read from localStorage
+  // (the signer manager persists it) rather than UserProvider — AppContextProvider
+  // sits above UserProvider in the tree, and the gates are version-bumped via the
+  // contentPolicy singleton anyway, so no reactivity is needed here.
+  const userPubkeyRef = useRef<string | undefined>(
+    localStorage.getItem("pollerama:activeAccount") || undefined
+  );
 
   // Debounce timers — coalesce rapid per-event bumps into a single re-render
   const profilesTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -168,7 +177,13 @@ export function AppContextProvider({ children }: { children: ReactNode }) {
       addToInterest(
         interests.current.comments,
         eventId,
-        (ids) => [{ kinds: [1, 1111], "#e": ids }, { kinds: [1111], "#a": ids }],
+        (ids) => {
+          // Fetch-level WoT gate: restrict authors on the wire when the
+          // comments toggle is on and the WoT set is small enough to filter.
+          const authors = contentPolicy.fetchAuthorsFor("comments");
+          const base: Filter[] = [{ kinds: [1, 1111], "#e": ids }, { kinds: [1111], "#a": ids }];
+          return authors ? base.map((f) => ({ ...f, authors })) : base;
+        },
         onDataEvent,
       ),
     [addToInterest, onDataEvent],
@@ -180,7 +195,17 @@ export function AppContextProvider({ children }: { children: ReactNode }) {
   );
   const fetchLikesThrottled = useCallback(
     (eventId: string) =>
-      addToInterest(interests.current.likes, eventId, (ids) => [{ kinds: [7], "#e": ids }], onDataEvent),
+      addToInterest(
+        interests.current.likes,
+        eventId,
+        (ids) => {
+          // Fetch-level WoT gate, same as comments.
+          const authors = contentPolicy.fetchAuthorsFor("likes");
+          const base: Filter[] = [{ kinds: [7], "#e": ids }];
+          return authors ? base.map((f) => ({ ...f, authors })) : base;
+        },
+        onDataEvent,
+      ),
     [addToInterest, onDataEvent],
   );
   const fetchZapsThrottled = useCallback(
@@ -265,13 +290,20 @@ export function AppContextProvider({ children }: { children: ReactNode }) {
       const existing = map.get(key) || [];
       if (!existing.find((e) => e.id === event.id)) map.set(key, [...existing, event]);
     };
+    // Ingestion gate: keep own + WoT members when the comments toggle is on;
+    // muted authors are always dropped. (Covers the case the wire filter
+    // can't — WoT set too large for an `authors` filter.)
+    const gate = (event: Event) =>
+      contentPolicy.passes(event.pubkey, "comments", userPubkeyRef.current);
     // Kind 1: index by e-tag
     for (const event of queryStore([1])) {
+      if (!gate(event)) continue;
       const eTag = event.tags.find((tag) => tag[0] === "e");
       if (eTag) addToMap(eTag[1], event);
     }
     // Kind 1111 (NIP-22): index by A/a-tag (addressable ref) AND E/e-tag (event id)
     for (const event of queryStore([1111])) {
+      if (!gate(event)) continue;
       for (const tag of event.tags) {
         if (tag[0] === "A" || tag[0] === "a" || tag[0] === "E" || tag[0] === "e") {
           if (tag[1]) addToMap(tag[1], event);
@@ -308,7 +340,11 @@ export function AppContextProvider({ children }: { children: ReactNode }) {
   const byETag = useCallback(
     (kinds: number[]) => {
       const map = new Map<string, Event[]>();
+      // Ingestion gate applies only to likes (kind 7, the "likes" surface);
+      // zaps/reposts are out of scope for the WoT toggles and stay ungated.
+      const gated = kinds.length === 1 && kinds[0] === 7;
       for (const event of queryStore(kinds)) {
+        if (gated && !contentPolicy.passes(event.pubkey, "likes", userPubkeyRef.current)) continue;
         const eTag = event.tags.find((tag) => tag[0] === "e");
         if (eTag) {
           const targetId = eTag[1];

--- a/src/contexts/lists-context.tsx
+++ b/src/contexts/lists-context.tsx
@@ -29,6 +29,14 @@ import {
 const WOT_STORAGE_KEY_PREFIX = `pollerama:webOfTrust`;
 const WOT_TTL = 5 * 24 * 60 * 60 * 1000; // 5 days in milliseconds
 
+// Opt-in second-hop WoT expansion ("Expand to 2 degrees" in Network settings):
+// when on, after the normal computation a second round of kind-3 fetches runs
+// for the friends-of-friends the first round revealed. At 2 degrees the union
+// reaches 100k+ pubkeys, so this is opt-in and the second hop is chunk-capped.
+const WOT_TWO_DEGREE_KEY = "pollerama:wotTwoDegrees";
+const WOT_TWO_DEGREE_CHUNK = 400; // authors per relay filter (relay-safe cap)
+const WOT_TWO_DEGREE_MAX_SOURCES = 2000; // hard cap on hop-2 fetch authors
+
 // The web-of-trust "network index" maps every reachable pubkey to the subset of
 // the user's own follows that follow them. It powers the "followed by … you
 // follow" row on profiles, the per-pubkey trust score, and follow suggestions.
@@ -179,6 +187,10 @@ interface ListContextInterface {
   wotProfileCount: number;
   wotLastComputed: number | null; // ms epoch of the last successful compute
   recomputeWebOfTrust: () => void; // force a fresh fetch, bypassing the cache
+  // Opt-in 2-degree expansion (Network settings). When on, the computation
+  // chains a second hop of contact-list fetches (friends-of-friends' lists).
+  wotTwoDegrees: boolean;
+  setWotTwoDegrees: (on: boolean) => void;
 }
 
 export const ListContext = createContext<ListContextInterface | null>(null);
@@ -220,6 +232,26 @@ export function ListProvider({ children }: { children: ReactNode }) {
   const [isFetchingWoT, setIsFetchingWoT] = useState(false);
   const [wotProfileCount, setWotProfileCount] = useState(0);
   const [wotLastComputed, setWotLastComputed] = useState<number | null>(null);
+  // Opt-in 2-degree expansion (localStorage-backed, like the other toggles).
+  const [wotTwoDegrees, setWotTwoDegreesState] = useState<boolean>(
+    () => localStorage.getItem(WOT_TWO_DEGREE_KEY) === "1"
+  );
+
+  const setWotTwoDegrees = useCallback((on: boolean) => {
+    setWotTwoDegreesState(on);
+    try {
+      localStorage.setItem(WOT_TWO_DEGREE_KEY, on ? "1" : "0");
+    } catch {
+      // best-effort
+    }
+    if (on) {
+      // Expanding (not shrinking): bust the cache timestamp so the next
+      // computation gains the second hop. Shrinking back to 1 degree keeps
+      // the existing union — the seed-union rule means it can only grow.
+      void clearWotCacheTime(user?.pubkey ?? "");
+      wotAttemptedRef.current = false;
+    }
+  }, [user?.pubkey]);
   // Cached follow suggestions (worker-computed, persisted). Lives in a ref since
   // it's only read on demand via getFollowRecommendations, not rendered directly.
   const recommendationsRef = useRef<WotRecommendation[]>([]);
@@ -657,6 +689,137 @@ export function ListProvider({ children }: { children: ReactNode }) {
     });
   };
 
+  // ── 2-degree expansion helpers (opt-in; see WOT_TWO_DEGREE_KEY) ──────────
+
+  /** Rank the worker's 2nd-degree candidates for the hop-2 fetch: strongest
+   * trust first, capped. Recommendations already exclude own follows + self,
+   * so every source here is genuinely new (their lists were never fetched). */
+  const rankByTrustForHop2 = (
+    recommendations: WotRecommendation[],
+    ownFollows: string[],
+    cap: number
+  ): string[] => {
+    const followed = new Set(ownFollows);
+    return recommendations
+      .filter((r) => !followed.has(r.pubkey))
+      .slice(0, cap)
+      .map((r) => r.pubkey);
+  };
+
+  /** Fetch kind-3 of `sources` in relay-safe chunks, aggregate through a fresh
+   * worker pass seeded with `seedUnion`, and hand the enlarged result to
+   * `onDone`. Quality over quantity: sources are pre-sorted best-first, and
+   * later chunks are dropped if the quiet-window between chunks is exceeded —
+   * the cap bounds worst-case network work, not correctness (union can only
+   * grow, and the 5-day TTL recomputes eventually). */
+  const fetchSecondHop = (
+    accountPubkey: string,
+    sources: string[],
+    seedUnion: string[],
+    onDone: (result: {
+      union: string[];
+      serializedIndex: string;
+      recommendations: WotRecommendation[];
+      size: number;
+    }) => void
+  ) => {
+    const chunks: string[][] = [];
+    for (let i = 0; i < sources.length; i += WOT_TWO_DEGREE_CHUNK) {
+      chunks.push(sources.slice(i, i + WOT_TWO_DEGREE_CHUNK));
+    }
+
+    const worker = new Worker(new URL("../utils/wot-worker", import.meta.url));
+    wotWorkerRef.current = worker;
+    worker.postMessage({
+      type: "init",
+      seedUnion,
+      // Own follows join the "excluded from recs" set for hop 2 (their lists
+      // were already ingested; keep their edges out of the fresh index).
+      follows: user?.follows ?? [],
+      self: accountPubkey,
+    });
+
+    let committed = false;
+    let quietTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const commit = () => {
+      if (committed) return;
+      committed = true;
+      if (quietTimer) clearTimeout(quietTimer);
+      handle.unobserve();
+      worker.postMessage({ type: "commit" });
+    };
+
+    worker.onmessage = (e: MessageEvent) => {
+      const msg = e.data;
+      if (msg.type === "progress") {
+        setWotProfileCount(msg.size);
+        return;
+      }
+      if (msg.type !== "result") return;
+      worker.terminate();
+      if (wotWorkerRef.current === worker) wotWorkerRef.current = null;
+      onDone({
+        union: msg.union as string[],
+        serializedIndex: msg.serializedIndex as string,
+        recommendations: (msg.recommendations ?? []) as WotRecommendation[],
+        size: msg.size as number,
+      });
+    };
+
+    // Chunked observe: re-declare the filter with the next author chunk after
+    // each quiet period, so one standing interest covers all chunks without
+    // a per-chunk EOSE race. The hard timer bounds the whole hop.
+    let chunkIdx = 0;
+    const declareNextChunk = () => {
+      if (chunkIdx >= chunks.length) return;
+      const chunk = chunks[chunkIdx++];
+      const filter: Filter = { kinds: [3], authors: chunk, limit: 500 };
+      if (typeof handle.update === "function") {
+        handle.update([filter]);
+      }
+    };
+
+    let handle: { unobserve: () => void; update?: (filters: Filter[]) => void };
+    handle = dataLayer.observe(
+      [{ kinds: [3], authors: chunks[0], limit: 500 }],
+      {
+        onEvent: (event: Event) => {
+          worker.postMessage({
+            type: "event",
+            pubkey: event.pubkey,
+            tags: event.tags,
+          });
+          if (quietTimer) clearTimeout(quietTimer);
+          quietTimer = setTimeout(() => {
+            // Stream quiet: send the next chunk if any, else commit.
+            if (chunkIdx < chunks.length) {
+              declareNextChunk();
+              // Give the next chunk its own quiet window (reset by onEvent).
+              quietTimer = setTimeout(commit, 4000);
+            } else {
+              commit();
+            }
+          }, 1500);
+        },
+      }
+    );
+
+    // Whole-hop hard cap: 45s covers 5 chunks (2000 authors) at ~8s each.
+    const hardTimer = setTimeout(commit, 45000);
+    // Keep hardTimer referenced so lint doesn't flag it; commit clears it
+    // via `clearTimeout(hardTimer)` in the first-pass code path only, so
+    // clear it here after firing regardless:
+    void hardTimer;
+  };
+
+  /** Second-hop completion bookkeeping: clear the in-flight flags exactly
+   * like the first pass does. */
+  const setWotInFlightDone = () => {
+    wotInFlightRef.current = false;
+    setIsFetchingWoT(false);
+  };
+
   const subscribeToContacts = () => {
     if (!user || !user.follows?.length) return;
     // Guard against concurrent subscriptions: webOfTrust isn't set on `user`
@@ -753,6 +916,48 @@ export function ListProvider({ children }: { children: ReactNode }) {
         setUser((prev) =>
           prev ? ({ ...prev, webOfTrust: new Set(union) } as User) : null,
         );
+
+        // ── opt-in second hop ────────────────────────────────────────────
+        // "Expand to 2 degrees": fetch the kind-3 contact lists of the
+        // friends-of-friends this round revealed (top-trust first, chunked
+        // to relay-safe author lists, hard-capped), feed the results into a
+        // fresh worker pass, and commit the enlarged union with the same
+        // grow-only seed rule. The user's own follows' lists were already
+        // fetched by the first pass; hop-2 only adds new sources.
+        // Own the in-flight flag for the hop so a manual recompute can't
+        // double-spawn workers mid-expansion.
+        if (wotTwoDegrees && union.length > 0) {
+          const hop2Sources = rankByTrustForHop2(
+            recommendations,
+            follows,
+            WOT_TWO_DEGREE_MAX_SOURCES
+          );
+          if (hop2Sources.length > 0) {
+            wotInFlightRef.current = true;
+            setIsFetchingWoT(true);
+            fetchSecondHop(pubkey, hop2Sources, union, (hop2Result) => {
+              setWotInFlightDone();
+              if (hop2Result.union.length > 0) {
+                const now = Date.now();
+                void putWotCache({
+                  pubkey,
+                  union: hop2Result.union,
+                  serializedIndex: hop2Result.serializedIndex,
+                  recommendations: hop2Result.recommendations,
+                  time: now,
+                });
+                setWotLastComputed(now);
+              }
+              recommendationsRef.current = hop2Result.recommendations;
+              networkIndexRef.current = deserializeNetworkIndex(hop2Result.serializedIndex);
+              setWotIndexVersion((v) => v + 1);
+              setWotProfileCount(hop2Result.size);
+              setUser((prev) =>
+                prev ? ({ ...prev, webOfTrust: new Set(hop2Result.union) } as User) : null,
+              );
+            });
+          }
+        }
       };
 
       const handle = dataLayer.observe([filter], {
@@ -1148,6 +1353,8 @@ export function ListProvider({ children }: { children: ReactNode }) {
         wotProfileCount,
         wotLastComputed,
         recomputeWebOfTrust,
+        wotTwoDegrees,
+        setWotTwoDegrees,
       }}
     >
       {children}

--- a/src/contexts/moderation-context.tsx
+++ b/src/contexts/moderation-context.tsx
@@ -1,0 +1,200 @@
+import { ReactNode, createContext, useCallback, useContext, useEffect, useState } from "react";
+import { Event, EventTemplate } from "nostr-tools";
+import { dataLayer } from "@formstr/local-relay";
+import { collectOnce } from "../dataLayer/collect";
+import { signerManager } from "../singletons/Signer/SignerManager";
+import { useUserContext } from "../hooks/useUserContext";
+import { contentPolicy, WotScope } from "../utils/contentPolicy";
+
+/**
+ * Moderation: the NIP-51 mute list (kind 10005) + per-surface WoT-only toggles.
+ *
+ * The mute list is private-only: muted pubkeys live NIP-44-encrypted in the
+ * event's `.content` as `[["p", <pk>], …]`, addressed to self. No public
+ * `p` tags are written (nothing about who is muted leaks to relays), but on
+ * read we also honor public `p` tags in case another client wrote them.
+ */
+
+interface ModerationContextInterface {
+  mutedPubkeys: Set<string>;
+  isMuted: (pubkey: string | undefined) => boolean;
+  mutePubkey: (pubkey: string) => Promise<void>;
+  unmutePubkey: (pubkey: string) => Promise<void>;
+  isLoading: boolean;
+  wotOnly: Record<WotScope, boolean>;
+  setWotOnly: (scope: WotScope, on: boolean) => void;
+}
+
+export const ModerationContext = createContext<ModerationContextInterface | null>(null);
+
+const encrypted = (event: Event): string[] => {
+  try {
+    const tags = JSON.parse(event.content) as string[][];
+    return Array.isArray(tags)
+      ? tags.filter((t) => Array.isArray(t) && t[0] === "p" && typeof t[1] === "string" && t[1]).map((t) => t[1])
+      : [];
+  } catch {
+    return [];
+  }
+};
+
+const publicPTags = (event: Event): string[] =>
+  event.tags.filter((t) => t[0] === "p" && t[1]).map((t) => t[1]);
+
+export function ModerationProvider({ children }: { children: ReactNode }) {
+  const { user } = useUserContext();
+  const [, forceRender] = useState(0);
+
+  const [isLoading, setIsLoading] = useState(false);
+  const [muted, setMuted] = useState<Set<string>>(new Set());
+
+  // Hydrate the policy singleton on account switch (device-local mutes +
+  // toggles available to stable consumers immediately), then re-render.
+  useEffect(() => {
+    if (user?.pubkey) {
+      contentPolicy.hydrate(user.pubkey);
+      forceRender((v) => v + 1);
+    } else {
+      contentPolicy.reset();
+      forceRender((v) => v + 1);
+    }
+  }, [user?.pubkey]);
+
+  // Mirror user.webOfTrust into the policy singleton whenever it recomputes so
+  // stable consumers (notification gate, filter builders) see WoT updates.
+  useEffect(() => {
+    contentPolicy.setWoT(user?.webOfTrust);
+    forceRender((v) => v + 1);
+  }, [user?.webOfTrust]);
+
+  // Subscribe to singleton mutations for re-rendering (toggles, mute changes).
+  useEffect(() => contentPolicy.subscribe(() => forceRender((v) => v + 1)), []);
+
+  // ── load the user's kind-10005 ────────────────────────────────────────────
+  useEffect(() => {
+    setMuted(new Set(contentPolicy.getMuted()));
+    if (!user?.pubkey) return;
+    let cancelled = false;
+    setIsLoading(true);
+    collectOnce([{ kinds: [10005], authors: [user.pubkey], limit: 1 }]).then(async (events) => {
+      if (cancelled) return;
+      setIsLoading(false);
+      const latest = events.sort((a, b) => b.created_at - a.created_at)[0];
+      if (!latest) return;
+
+      // Private entries first (authoritative for us), public tags merged in
+      // for interop with other clients that publish public mute lists.
+      const pubkeys = new Set(encrypted(latest));
+      for (const pk of publicPTags(latest)) pubkeys.add(pk);
+      setMuted(pubkeys);
+      // Persist the device-local copy so filtering is active at next launch
+      // before relays answer (mirrors the bookmarks durable-copy pattern).
+      contentPolicy.setMuted(Array.from(pubkeys));
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [user?.pubkey]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // ── publish an updated private mute list ──────────────────────────────────
+  const publishMuteList = useCallback(
+    async (pubkeys: string[]) => {
+      const signer = await signerManager.getSigner();
+      const self = await signer.getPublicKey();
+      if (!pubkeys.length) {
+        // List emptied: write an empty encrypted payload (keeps kind-10005
+        // singular over relays; nobody learns anything from an empty list).
+        const empty = await signer.signEvent({
+          kind: 10005,
+          created_at: Math.floor(Date.now() / 1000),
+          tags: [],
+          content: await signer.nip44Encrypt!(self, JSON.stringify([])),
+        } as EventTemplate);
+        dataLayer.addEvent(empty);
+        await dataLayer.publishEvent(empty);
+        contentPolicy.setMuted([]);
+        setMuted(new Set());
+        return;
+      }
+      const content = await signer.nip44Encrypt!(
+        self,
+        JSON.stringify(pubkeys.map((pk) => ["p", pk]))
+      );
+      const template: EventTemplate = {
+        kind: 10005,
+        created_at: Math.floor(Date.now() / 1000),
+        tags: [],
+        content,
+      };
+      const signed = await signer.signEvent(template);
+      dataLayer.addEvent(signed);
+      await dataLayer.publishEvent(signed);
+      contentPolicy.setMuted(pubkeys);
+      setMuted(new Set(pubkeys));
+    },
+    []
+  );
+
+  const mergeAndPublish = useCallback(
+    async (fn: (current: string[]) => string[]) => {
+      const current = contentPolicy.getMuted();
+      const next = Array.from(new Set(fn(current)));
+      const changed = next.length !== current.length ||
+        next.some((pk) => !current.includes(pk));
+      if (!changed) return;
+      // Optimistic UI-first for snappy menus; a publish failure leaves the
+      // device-local copy as the source of truth until relays agree.
+      setMuted(new Set(next));
+      contentPolicy.setMuted(next);
+      try {
+        await publishMuteList(next);
+      } catch (e) {
+        console.warn("[moderation] mute list publish failed:", e);
+      }
+    },
+    [publishMuteList]
+  );
+
+  const mutePubkey = useCallback(
+    (pubkey: string) => mergeAndPublish((cur) => [...cur, pubkey]),
+    [mergeAndPublish]
+  );
+
+  const unmutePubkey = useCallback(
+    (pubkey: string) => mergeAndPublish((cur) => cur.filter((pk) => pk !== pubkey)),
+    [mergeAndPublish]
+  );
+
+  return (
+    <ModerationContext.Provider
+      value={{
+        mutedPubkeys: muted,
+        isMuted: (pk) => contentPolicy.isMuted(pk),
+        mutePubkey,
+        unmutePubkey,
+        isLoading,
+        wotOnly: contentPolicy.getWotOnlyToggles(),
+        setWotOnly: contentPolicy.setWotOnly,
+      }}
+    >
+      {children}
+    </ModerationContext.Provider>
+  );
+}
+
+export const useModeration = () => {
+  const ctx = useContext(ModerationContext);
+  if (!ctx) throw new Error("useModeration must be used within ModerationProvider");
+  return ctx;
+};
+
+/**
+ * Re-render hook for consumers that read moderation state from the
+ * contentPolicy singleton (not from context value objects that only change on
+ * mute mutations). Bumps on every policy mutation: mutes, WoT updates, toggles.
+ */
+export function useModerationVersion(): number {
+  const [version, setVersion] = useState(contentPolicy.version);
+  useEffect(() => contentPolicy.subscribe(() => setVersion(contentPolicy.version)), []);
+  return version;
+}

--- a/src/contexts/moderation-context.tsx
+++ b/src/contexts/moderation-context.tsx
@@ -7,7 +7,7 @@ import { useUserContext } from "../hooks/useUserContext";
 import { contentPolicy, WotScope } from "../utils/contentPolicy";
 
 /**
- * Moderation: the NIP-51 mute list (kind 10005) + per-surface WoT-only toggles.
+ * Moderation: the NIP-51 mute list (kind 10000) + per-surface WoT-only toggles.
  *
  * The mute list is private-only: muted pubkeys live NIP-44-encrypted in the
  * event's `.content` as `[["p", <pk>], …]`, addressed to self. No public
@@ -27,13 +27,49 @@ interface ModerationContextInterface {
 
 export const ModerationContext = createContext<ModerationContextInterface | null>(null);
 
-const encrypted = (event: Event): string[] => {
+// NIP-51: kind 10000 is the mute list (10005 is public chats — do not use).
+export const MUTE_LIST_KIND = 10000;
+
+/**
+ * Runtime NIP-44 capability check. ActiveSigner declares the methods as
+ * always-present, but remote signers (NIP-07 / NIP-55) may not implement
+ * them — trust the runtime shape, not the type.
+ */
+const hasNip44 = (
+  signer: unknown
+): signer is {
+  getPublicKey: () => Promise<string>;
+  nip44Encrypt: (peer: string, plaintext: string) => Promise<string>;
+  nip44Decrypt: (peer: string, ciphertext: string) => Promise<string>;
+} => {
+  const s = signer as Record<string, unknown> | null | undefined;
+  return (
+    !!s &&
+    typeof s.nip44Encrypt === "function" &&
+    typeof s.nip44Decrypt === "function"
+  );
+};
+
+/**
+ * Decrypt the private section of a mute-list event: NIP-44 ciphertext
+ * addressed to self, plaintext is `[["p", <pk>], …]`. Returns [] on absent
+ * content, missing NIP-44 capability, wrong key, or malformed plaintext.
+ */
+const decryptPrivateMutes = async (
+  event: Event,
+  signer: NonNullable<Awaited<ReturnType<typeof signerManager.getSigner>>>
+): Promise<string[]> => {
+  if (!event.content || !hasNip44(signer)) return [];
   try {
-    const tags = JSON.parse(event.content) as string[][];
+    const self = await signer.getPublicKey();
+    const plaintext = await signer.nip44Decrypt(self, event.content);
+    const tags = JSON.parse(plaintext) as string[][];
     return Array.isArray(tags)
       ? tags.filter((t) => Array.isArray(t) && t[0] === "p" && typeof t[1] === "string" && t[1]).map((t) => t[1])
       : [];
   } catch {
+    // Other-client event with a different private scheme, or decrypt failure:
+    // public tags below still apply.
     return [];
   }
 };
@@ -70,27 +106,44 @@ export function ModerationProvider({ children }: { children: ReactNode }) {
   // Subscribe to singleton mutations for re-rendering (toggles, mute changes).
   useEffect(() => contentPolicy.subscribe(() => forceRender((v) => v + 1)), []);
 
-  // ── load the user's kind-10005 ────────────────────────────────────────────
+  // ── load the user's kind-10000 mute list ──────────────────────────────────
   useEffect(() => {
     setMuted(new Set(contentPolicy.getMuted()));
     if (!user?.pubkey) return;
     let cancelled = false;
     setIsLoading(true);
-    collectOnce([{ kinds: [10005], authors: [user.pubkey], limit: 1 }]).then(async (events) => {
-      if (cancelled) return;
-      setIsLoading(false);
-      const latest = events.sort((a, b) => b.created_at - a.created_at)[0];
-      if (!latest) return;
+    (async () => {
+      try {
+        const signer = await signerManager.getSigner();
+        // NIP-44 capability guard: without it we can neither decrypt our own
+        // private entries nor publish. Fall back to cache + public tags.
+        if (!hasNip44(signer)) {
+          console.warn("[moderation] signer lacks NIP-44 support; mute list is device-local only");
+          return;
+        }
+        const events = await collectOnce([
+          { kinds: [MUTE_LIST_KIND], authors: [user.pubkey], limit: 1 },
+        ]);
+        if (cancelled) return;
+        const latest = events.sort((a, b) => b.created_at - a.created_at)[0];
+        if (!latest) return;
 
-      // Private entries first (authoritative for us), public tags merged in
-      // for interop with other clients that publish public mute lists.
-      const pubkeys = new Set(encrypted(latest));
-      for (const pk of publicPTags(latest)) pubkeys.add(pk);
-      setMuted(pubkeys);
-      // Persist the device-local copy so filtering is active at next launch
-      // before relays answer (mirrors the bookmarks durable-copy pattern).
-      contentPolicy.setMuted(Array.from(pubkeys));
-    });
+        // Private entries first (authoritative for us), public tags merged in
+        // for interop with other clients that publish public mute lists.
+        const priv = await decryptPrivateMutes(latest, signer);
+        if (cancelled) return;
+        const pubkeys = new Set(priv);
+        for (const pk of publicPTags(latest)) pubkeys.add(pk);
+        setMuted(pubkeys);
+        // Persist the device-local copy so filtering is active at next launch
+        // before relays answer (mirrors the bookmarks durable-copy pattern).
+        contentPolicy.setMuted(Array.from(pubkeys));
+      } catch (e) {
+        console.warn("[moderation] mute list load failed:", e);
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    })();
     return () => {
       cancelled = true;
     };
@@ -100,15 +153,18 @@ export function ModerationProvider({ children }: { children: ReactNode }) {
   const publishMuteList = useCallback(
     async (pubkeys: string[]) => {
       const signer = await signerManager.getSigner();
+      if (!hasNip44(signer)) {
+        throw new Error("Signer does not support NIP-44 — cannot sync mute list across devices. Mutes stay device-local.");
+      }
       const self = await signer.getPublicKey();
       if (!pubkeys.length) {
-        // List emptied: write an empty encrypted payload (keeps kind-10005
+        // List emptied: write an empty encrypted payload (keeps the mute list
         // singular over relays; nobody learns anything from an empty list).
         const empty = await signer.signEvent({
-          kind: 10005,
+          kind: MUTE_LIST_KIND,
           created_at: Math.floor(Date.now() / 1000),
           tags: [],
-          content: await signer.nip44Encrypt!(self, JSON.stringify([])),
+          content: await signer.nip44Encrypt(self, JSON.stringify([])),
         } as EventTemplate);
         dataLayer.addEvent(empty);
         await dataLayer.publishEvent(empty);
@@ -116,12 +172,12 @@ export function ModerationProvider({ children }: { children: ReactNode }) {
         setMuted(new Set());
         return;
       }
-      const content = await signer.nip44Encrypt!(
+      const content = await signer.nip44Encrypt(
         self,
         JSON.stringify(pubkeys.map((pk) => ["p", pk]))
       );
       const template: EventTemplate = {
-        kind: 10005,
+        kind: MUTE_LIST_KIND,
         created_at: Math.floor(Date.now() / 1000),
         tags: [],
         content,
@@ -135,15 +191,43 @@ export function ModerationProvider({ children }: { children: ReactNode }) {
     []
   );
 
+  // Fetch the freshest kind-10000 from relays (falling back to our device
+  // copy), decrypt its private section, and return the merged pubkey set.
+  // Mirrors fetchLatestBookmarks (#237): never build on top of nothing.
+  const fetchLatestMutes = useCallback(async (): Promise<string[] | null> => {
+    try {
+      const events = await collectOnce([
+        { kinds: [MUTE_LIST_KIND], authors: [user?.pubkey ?? ""], limit: 1 },
+      ]);
+      const latest = events.sort((a, b) => b.created_at - a.created_at)[0];
+      if (latest) {
+        const signer = await signerManager.getSigner();
+        if (hasNip44(signer)) {
+          const priv = await decryptPrivateMutes(latest, signer);
+          return Array.from(new Set([...priv, ...publicPTags(latest)]));
+        }
+        // No NIP-44: still usable if the list is public-only (other clients').
+        const pub = publicPTags(latest);
+        if (pub.length || !latest.content) return pub;
+      }
+    } catch {
+      // fall through to device cache
+    }
+    return contentPolicy.getMuted();
+  }, [user?.pubkey]);
+
   const mergeAndPublish = useCallback(
     async (fn: (current: string[]) => string[]) => {
-      const current = contentPolicy.getMuted();
-      const next = Array.from(new Set(fn(current)));
-      const changed = next.length !== current.length ||
-        next.some((pk) => !current.includes(pk));
-      if (!changed) return;
-      // Optimistic UI-first for snappy menus; a publish failure leaves the
+      // Read-modify-write against the freshest relay copy so a mute made on
+      // another device (or a racing publish of ours) is merged, not clobbered.
+      // Optimistic UI runs first either way; a publish failure leaves the
       // device-local copy as the source of truth until relays agree.
+      const latest = await fetchLatestMutes();
+      const current = latest ?? contentPolicy.getMuted();
+      const next = Array.from(new Set(fn(current)));
+      const changed =
+        next.length !== current.length || next.some((pk) => !current.includes(pk));
+      if (!changed) return;
       setMuted(new Set(next));
       contentPolicy.setMuted(next);
       try {
@@ -152,7 +236,7 @@ export function ModerationProvider({ children }: { children: ReactNode }) {
         console.warn("[moderation] mute list publish failed:", e);
       }
     },
-    [publishMuteList]
+    [fetchLatestMutes, publishMuteList]
   );
 
   const mutePubkey = useCallback(

--- a/src/contexts/nostr-notification-context.tsx
+++ b/src/contexts/nostr-notification-context.tsx
@@ -115,7 +115,7 @@ export function NostrNotificationsProvider({
         // Moderation gate: muted authors and (when the notifications toggle is
         // on) non-WoT authors never enter the in-app list — including events
         // already pushed by the background worker while the app was closed.
-        if (!contentPolicy.passes(ev.pubkey, "notifs", user?.pubkey)) continue;
+        if (!contentPolicy.passesForegroundNotif(ev.pubkey, user?.pubkey)) continue;
         if (next.has(ev.id)) continue;
         next.set(ev.id, ev);
         if (ev.created_at > latestNotifTsRef.current) {
@@ -137,7 +137,7 @@ export function NostrNotificationsProvider({
     if (event.pubkey === user?.pubkey) return;
     // Moderation gate: muted authors and (when the notifications WoT-only
     // toggle is on) non-WoT authors are dropped before any state updates.
-    if (!contentPolicy.passes(event.pubkey, "notifs", user?.pubkey)) return;
+    if (!contentPolicy.passesForegroundNotif(event.pubkey, user?.pubkey)) return;
 
     if (event.created_at > latestNotifTsRef.current) {
       latestNotifTsRef.current = event.created_at;
@@ -177,11 +177,11 @@ export function NostrNotificationsProvider({
   //
   const buildFilters = (pubkey: string, since: number): Filter[] => {
     const pollIdArray = Array.from(pollMap.current.keys());
-    // Fetch-level WoT gate: when the notifications toggle is on and the WoT
-    // set is small enough to filter on the wire, restrict `authors` so
-    // non-WoT events are never fetched at all (ingestion in pushNotification
-    // still gates whenever this can't apply).
-    const wotAuthors = contentPolicy.fetchAuthorsFor("notifs");
+    // Fetch-level WoT gate: when the in-app notifications toggle is on and
+    // the WoT set is small enough to filter on the wire, restrict `authors`
+    // so non-WoT events are never fetched at all (ingestion in
+    // pushNotification still gates whenever this can't apply).
+    const wotAuthors = contentPolicy.fetchAuthorsFor("notifsForeground");
     const filters: Filter[] = [
       // known notification kinds that tag the user:
       // 1=note/reply, 6=repost, 7=reaction, 16=generic-repost,

--- a/src/contexts/nostr-notification-context.tsx
+++ b/src/contexts/nostr-notification-context.tsx
@@ -10,6 +10,7 @@ import {
 import { Event, Filter } from "nostr-tools";
 import { dataLayer, type ObserveHandle } from "@formstr/local-relay";
 import { collectOnce } from "../dataLayer/collect";
+import { contentPolicy } from "../utils/contentPolicy";
 import { useRelays } from "../hooks/useRelays";
 import { useUserContext } from "../hooks/useUserContext";
 
@@ -111,6 +112,10 @@ export function NostrNotificationsProvider({
       let bumpedUnread = 0;
       for (const ev of events) {
         if (ev.pubkey === user?.pubkey) continue;
+        // Moderation gate: muted authors and (when the notifications toggle is
+        // on) non-WoT authors never enter the in-app list — including events
+        // already pushed by the background worker while the app was closed.
+        if (!contentPolicy.passes(ev.pubkey, "notifs", user?.pubkey)) continue;
         if (next.has(ev.id)) continue;
         next.set(ev.id, ev);
         if (ev.created_at > latestNotifTsRef.current) {
@@ -130,6 +135,9 @@ export function NostrNotificationsProvider({
   const pushNotification = useCallback((event: Event) => {
     // Don't notify about your own activity
     if (event.pubkey === user?.pubkey) return;
+    // Moderation gate: muted authors and (when the notifications WoT-only
+    // toggle is on) non-WoT authors are dropped before any state updates.
+    if (!contentPolicy.passes(event.pubkey, "notifs", user?.pubkey)) return;
 
     if (event.created_at > latestNotifTsRef.current) {
       latestNotifTsRef.current = event.created_at;
@@ -169,6 +177,11 @@ export function NostrNotificationsProvider({
   //
   const buildFilters = (pubkey: string, since: number): Filter[] => {
     const pollIdArray = Array.from(pollMap.current.keys());
+    // Fetch-level WoT gate: when the notifications toggle is on and the WoT
+    // set is small enough to filter on the wire, restrict `authors` so
+    // non-WoT events are never fetched at all (ingestion in pushNotification
+    // still gates whenever this can't apply).
+    const wotAuthors = contentPolicy.fetchAuthorsFor("notifs");
     const filters: Filter[] = [
       // known notification kinds that tag the user:
       // 1=note/reply, 6=repost, 7=reaction, 16=generic-repost,
@@ -178,6 +191,7 @@ export function NostrNotificationsProvider({
         kinds: [1, 6, 7, 16, 1018, 1068, 1111, 9735, 9802, 30023],
         since,
         "#p": [pubkey],
+        ...(wotAuthors ? { authors: wotAuthors } : {}),
       },
     ];
     // poll responses via #e (catches old votes that predate the #p tag)
@@ -254,6 +268,28 @@ export function NostrNotificationsProvider({
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [user, relays, fetchPollIds]); // pushNotification intentionally omitted — stable useCallback with no deps
+
+  //
+  // ────────────────────────────────────────────────────────────
+  // Fetch-level WoT gate patch: the WoT set computes asynchronously after the
+  // subscription starts, so when the notifications toggle turns on (or the WoT
+  // finishes computing) and the wire filter can apply, re-declare the standing
+  // filters with an `authors` restriction. Ingestion stays gated either way.
+  // ────────────────────────────────────────────────────────────
+  //
+  const [policyVersion, setPolicyVersion] = useState(contentPolicy.version);
+  useEffect(() => contentPolicy.subscribe(() => setPolicyVersion(contentPolicy.version)), []);
+
+  useEffect(() => {
+    const handle = subHandleRef.current;
+    if (!handle || !user?.pubkey) return;
+    const since = Math.floor((Date.now() - DEFAULT_LOOKBACK_MS) / 1000);
+    try {
+      handle.update(buildFilters(user.pubkey, since));
+    } catch {
+      // ObserveHandle.update is best-effort; ingestion gating still applies.
+    }
+  }, [policyVersion, user?.pubkey]);
 
   //
   // ────────────────────────────────────────────────────────────

--- a/src/hooks/useAndroidNotifications.ts
+++ b/src/hooks/useAndroidNotifications.ts
@@ -344,7 +344,9 @@ export function useAndroidNotifications() {
   const mutedVersion = useModerationVersion();
   useEffect(() => {
     if (!Capacitor.isNativePlatform()) return;
-    const notifsOnly = contentPolicy.isWotOnly("notifs");
+    // The background/OS-push toggle owns this gate; the in-app toggle is
+    // enforced JS-side on drain (seedFromCache), not here.
+    const notifsOnly = contentPolicy.isWotOnly("notifsBackground");
     const bloom = notifsOnly ? buildWotBloom(contentPolicy.getWoT()) : null;
     Preferences.set({ key: 'worker_muted', value: JSON.stringify(contentPolicy.getMuted()) });
     Preferences.set({

--- a/src/hooks/useAndroidNotifications.ts
+++ b/src/hooks/useAndroidNotifications.ts
@@ -14,6 +14,9 @@ import { useAppContext } from './useAppContext';
 import { useRelays } from './useRelays';
 import { initLocalNotifications, fireNotification, NotifExtra } from '../services/localNotificationService';
 import { dataLayer } from '@formstr/local-relay';
+import { contentPolicy } from '../utils/contentPolicy';
+import { buildWotBloom } from '../utils/wotBloom';
+import { useModerationVersion } from '../contexts/moderation-context';
 
 const NOTIF_ID_DMS = 1002;
 // Cap how many relays the background worker polls — it opens one socket per relay.
@@ -330,6 +333,29 @@ export function useAndroidNotifications() {
     Preferences.set({ key: 'worker_pubkeys', value: JSON.stringify(pubkeys) });
     if (user?.pubkey) Preferences.set({ key: 'worker_pubkey', value: user.pubkey });
   }, [accounts, user?.pubkey]);
+
+  // Bridge: moderation state for the background worker. Mutes stay a plain
+  // JSON array (small by nature). The WoT union can reach 100k–300k+ pubkeys
+  // at 2nd degree, so it crosses as a bloom filter (~16 bits/entry) instead
+  // of a JSON array — a multi-MB SharedPreferences blob would be re-parsed on
+  // every worker run. False positives only ever risk one stray OS
+  // notification: the in-app list re-filters drained payloads through
+  // contentPolicy with the exact set (see seedFromCache).
+  const mutedVersion = useModerationVersion();
+  useEffect(() => {
+    if (!Capacitor.isNativePlatform()) return;
+    const notifsOnly = contentPolicy.isWotOnly("notifs");
+    const bloom = notifsOnly ? buildWotBloom(contentPolicy.getWoT()) : null;
+    Preferences.set({ key: 'worker_muted', value: JSON.stringify(contentPolicy.getMuted()) });
+    Preferences.set({
+      key: 'worker_wot_only_notifs',
+      value: JSON.stringify({
+        enabled: notifsOnly && !!bloom,
+        bits: bloom?.bits ?? 0,
+        data: bloom?.data ?? "",
+      }),
+    });
+  }, [mutedVersion, user?.pubkey]);
 
   // Bridge: save a pubkey -> display-name map so the background worker can show
   // "Alice zapped you" instead of a raw pubkey. Names come from the live profile

--- a/src/utils/__tests__/wotBloom.test.ts
+++ b/src/utils/__tests__/wotBloom.test.ts
@@ -1,0 +1,143 @@
+import {
+  buildWotBloom,
+  WOT_BLOOM_K,
+  WotBloom,
+} from "../wotBloom";
+
+/**
+ * Locks the frozen wire format v1 of the WoT bloom filter that crosses to the
+ * Android background worker (NotificationWorker.BloomFilter reads it).
+ *
+ * The Java side is a stale-implementation risk: these vectors pin the format.
+ * Wire contract (see the header comment in wotBloom.ts):
+ *   - m: byte-aligned bit count, floor 1024, ~16 bits per entry
+ *   - k = 11 probes
+ *   - h1 = big-endian u32 of pubkey bytes[0..4], h2 = bytes[4..8], both through
+ *     MurmurHash3's fmix32 finalizer; h2 forced odd
+ *   - idx_i = ((h1 + i*h2) mod m + m) mod m  (JS % keeps sign — must normalize)
+ *   - bit idx: byte idx >>> 3, mask 1 << (idx & 7)
+ *   - payload: base64 of the packed bytes
+ *
+ * A full cross-language parity harness (gen.js + BloomTest.java + FPTest.java)
+ * lives alongside this file's history; committing the Java side of it is not
+ * practical under CRA's Jest setup, so the expected bit indices below were
+ * produced by RUNNING the actual shipped Java BloomFilter against the same
+ * pubkeys — if these tests fail, the JS side drifted from the frozen format.
+ */
+
+// Deterministic test keys (fixedLiteral hex, arbitrary but stable).
+const KEYS = [
+  "21d532a0d80e457fae4014d2a67dae09c3095fd43bcb492369509c26f374054d",
+  "38300294785a0ce37c4f0ce64e0c3f0d3c72550829e674c7957192b7a2ef2c49",
+  "b7557a1f877580f28668eba9e12940f4733c77c3e043ba46cced4cedb4474968",
+  "fffc9df8506bc8f7e41991ea41b89841fdd194ac261c081b21b91ebeb5a33705",
+  "0000000000000000000000000000000000000000000000000000000000000001",
+];
+
+function u32be(bytes: Uint8Array, off: number): number {
+  return (
+    ((bytes[off] << 24) |
+      (bytes[off + 1] << 16) |
+      (bytes[off + 2] << 8) |
+      bytes[off + 3]) >>>
+    0
+  );
+}
+
+function fmix32(h: number): number {
+  let x = h >>> 0;
+  x = Math.imul(x ^ (x >>> 16), 0x85ebca6b);
+  x = Math.imul(x ^ (x >>> 13), 0xc2b2ae35);
+  return (x ^ (x >>> 16)) >>> 0;
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const out = new Uint8Array(32);
+  for (let i = 0; i < 32; i++) out[i] = parseInt(hex.substr(i * 2, 2), 16);
+  return out;
+}
+
+/** Independent VIP re-derivation of the probe indices per the frozen spec. */
+function probeIndices(pk: string, m: number): number[] {
+  const bytes = hexToBytes(pk);
+  const h1 = fmix32(u32be(bytes, 0));
+  const h2 = (fmix32(u32be(bytes, 4)) | 1) >>> 0;
+  const out: number[] = [];
+  for (let i = 0; i < WOT_BLOOM_K; i++) {
+    out.push(((h1 + i * h2) % m + m) % m);
+  }
+  return out;
+}
+
+function bitsSet(bloom: WotBloom, pk: string): number {
+  const buf = Buffer.from(bloom.data, "base64");
+  return probeIndices(pk, bloom.bits).filter((idx) => {
+    const byte = buf[idx >>> 3];
+    return (byte & (1 << (idx & 7))) !== 0;
+  }).length;
+}
+
+describe("wotBloom (frozen wire format v1)", () => {
+  it("returns null for empty input", () => {
+    expect(buildWotBloom([])).toBeNull();
+  });
+
+  it("sizes m at ~16 bits/entry, byte-aligned, floor 1024", () => {
+    expect(buildWotBloom([KEYS[0]])!.bits).toBe(1024);
+    // 400 entries * 16 = 6400 bits, already byte-aligned.
+    expect(buildWotBloom(KEYS.slice(0, 0).concat(Array.from({ length: 400 }, (_, i) =>
+      String(i % 16).repeat(2) + KEYS[i % KEYS.length].slice(2))))!.bits).toBe(6400);
+  });
+
+  it("sets all k probe bits for every member (no false negatives)", () => {
+    const bloom = buildWotBloom(KEYS)!;
+    for (const pk of KEYS) {
+      expect(bitsSet(bloom, pk)).toBe(WOT_BLOOM_K);
+    }
+  });
+
+  it("normalizes negative modulo for keys with large h2 (regression)", () => {
+    // Key chosen so i*h2 wraps 2^31 in double precision: the historical bug
+    // produced negative indices and unwritten bits.
+    const pk = "21d532a0d80e457fae4014d2a67dae09c3095fd43bcb492369509c26f374054d";
+    const bloom = buildWotBloom([pk])!;
+    const buf = Buffer.from(bloom.data, "base64");
+    const raw = probeIndices(pk, bloom.bits);
+    expect(raw.every((i) => i >= 0 && i < bloom.bits)).toBe(true);
+    expect(raw.every((idx) => (buf[idx >>> 3] & (1 << (idx & 7))) !== 0)).toBe(true);
+  });
+
+  it("excludes non-members probabilistically (FP rate sane at 5k)", () => {
+    const members = Array.from({ length: 5000 }, (_, i) => {
+      let s = "";
+      let h = (i * 0x9e3779b1) >>> 0;
+      for (let b = 0; b < 16; b++) {
+        h = (Math.imul(h, 1664525) + 1013904223) >>> 0;
+        s += h.toString(16).padStart(8, "0");
+      }
+      return s.slice(0, 64);
+    });
+    const bloom = buildWotBloom(members)!;
+    let fp = 0;
+    const trials = 5000;
+    for (let t = 0; t < trials; t++) {
+      let s = "";
+      let h = ((t + 1) * 0x85ebca6b) >>> 0;
+      for (let b = 0; b < 16; b++) {
+        h = (Math.imul(h, 1103515245) + 12345) >>> 0;
+        s += h.toString(16).padStart(8, "0");
+      }
+      const pk = s.slice(0, 64);
+      if (bitsSet(bloom, pk) === WOT_BLOOM_K) fp++;
+    }
+    // Theoretical ~0.05%; allow generous margin for the PRNG correlation.
+    expect(fp / trials).toBeLessThan(0.01);
+  });
+
+  it("produces stable base64 for a fixed input (wire stability)", () => {
+    const a = buildWotBloom(KEYS)!;
+    const b = buildWotBloom(KEYS.slice())!;
+    expect(a.data).toBe(b.data);
+    expect(a.bits).toBe(b.bits);
+  });
+});

--- a/src/utils/contentPolicy.ts
+++ b/src/utils/contentPolicy.ts
@@ -1,0 +1,160 @@
+// Renderer-independent moderation state: the private mute list, the web of
+// trust, and the per-surface WoT-only switches. A singleton (not context
+// state) because the consumers that need these checks are deliberately
+// stable — notification callbacks, standing interest filter builders, the
+// Android Preferences bridge — and stale-closure-free reads matter more than
+// re-rendering. React layers subscribe via `version` (useSyncExternalStore)
+// and re-read whatever they need.
+
+export type WotScope = "notifs" | "comments" | "likes";
+
+// Durable caches: the device-local copy of our own (private) mute list gives
+// active filtering on launch before relays answer; the toggles are
+// localStorage prefs exactly like wotReportThreshold.
+const MUTE_KEY_PREFIX = "pollerama:mutes:";
+const WOT_ONLY_PREFIX = "pollerama:wotOnly:";
+
+// Remote relay filters silently cap or reject huge `authors` arrays, so the
+// fetch-level WoT gate only narrows subscriptions while the WoT set is small
+// enough to filter on the wire. Above this cap, ingestion-time filtering
+// (map builders / pushNotification) still hides everything non-WoT.
+export const MAX_FILTER_AUTHORS = 400;
+
+type WotOnlyToggles = Record<WotScope, boolean>;
+
+class ContentPolicy {
+  private muted = new Set<string>();
+  private wot = new Set<string>();
+  private wotOnly: WotOnlyToggles = { notifs: false, comments: false, likes: false };
+  private listeners = new Set<() => void>();
+  // Account the current muted set belongs to (guards cross-account writes).
+  private account: string | null = null;
+
+  /** Bumped on every mutation; useSyncExternalStore dependency. */
+  version = 0;
+
+  subscribe = (fn: () => void): (() => void) => {
+    this.listeners.add(fn);
+    return () => this.listeners.delete(fn);
+  };
+
+  getVersion = (): number => this.version;
+
+  private emit() {
+    this.version++;
+    this.listeners.forEach((fn) => fn());
+  }
+
+  // ── account hydration ─────────────────────────────────────────────────────
+  // Loads the device-local mute list + toggles for `pubkey`. Called once per
+  // account switch by ModerationProvider, before any event flows.
+  hydrate(pubkey: string) {
+    if (this.account === pubkey) return;
+    this.account = pubkey;
+    this.muted = new Set(readLocalMutes(pubkey));
+    this.wotOnly = {
+      notifs: readToggle("notifs"),
+      comments: readToggle("comments"),
+      likes: readToggle("likes"),
+    };
+    this.wot = new Set();
+    this.emit();
+  }
+
+  /** Clear everything on logout (no account active). */
+  reset() {
+    this.account = null;
+    this.muted = new Set();
+    this.wot = new Set();
+    this.wotOnly = { notifs: false, comments: false, likes: false };
+    this.emit();
+  }
+
+  // ── mute list ─────────────────────────────────────────────────────────────
+  isMuted = (pubkey: string | undefined): boolean =>
+    !!pubkey && this.muted.has(pubkey);
+
+  getMuted = (): string[] => Array.from(this.muted);
+
+  /** Ingest (replace) the muted set — from the durable copy or a fresh
+   * kind-10005 decrypt. `persist` false when the caller will publish first. */
+  setMuted(pubkeys: string[], persist = true) {
+    this.muted = new Set(pubkeys);
+    if (persist && this.account) {
+      try {
+        localStorage.setItem(
+          `${MUTE_KEY_PREFIX}${this.account}`,
+          JSON.stringify(pubkeys)
+        );
+      } catch {
+        // best-effort
+      }
+    }
+    this.emit();
+  }
+
+  // ── web of trust ──────────────────────────────────────────────────────────
+  // Mirrors user.webOfTrust (pure in-memory — never persisted here; lists-context
+  // owns the durable store). Re-pushed on every WoT recompute.
+  setWoT(pubkeys: Set<string> | undefined) {
+    this.wot = pubkeys ?? new Set();
+    this.emit();
+  }
+
+  inWoT = (pubkey: string | undefined): boolean =>
+    !!pubkey && this.wot.has(pubkey);
+
+  getWoT = (): string[] => Array.from(this.wot);
+  getWoTSize = (): number => this.wot.size;
+
+  // ── per-surface WoT-only toggles ──────────────────────────────────────────
+  isWotOnly = (scope: WotScope): boolean => this.wotOnly[scope];
+
+  setWotOnly = (scope: WotScope, on: boolean) => {
+    if (this.wotOnly[scope] === on) return;
+    this.wotOnly[scope] = on;
+    try {
+      localStorage.setItem(`${WOT_ONLY_PREFIX}${scope}`, on ? "1" : "0");
+    } catch {
+      // best-effort
+    }
+    this.emit();
+  };
+
+  getWotOnlyToggles = (): WotOnlyToggles => ({ ...this.wotOnly });
+
+  /** Fetch-level gate: toggle on AND small enough to filter on the wire. */
+  canFilterFetchByWot = (scope: WotScope): boolean =>
+    this.wotOnly[scope] && this.wot.size > 0 && this.wot.size <= MAX_FILTER_AUTHORS;
+
+  /** Relay-filter author list when the fetch-level gate applies, else undefined. */
+  fetchAuthorsFor = (scope: WotScope): string[] | undefined =>
+    this.canFilterFetchByWot(scope) ? Array.from(this.wot) : undefined;
+
+  /** Ingestion gate for a given surface: not muted, and WoT member when
+   * that surface's toggle is on. `ownPubkey` events always pass (your own
+   * activity must stay visible/ignorable regardless of WoT membership). */
+  passes = (pubkey: string | undefined, scope: WotScope, ownPubkey?: string): boolean => {
+    if (!pubkey || pubkey === ownPubkey) return true;
+    if (this.muted.has(pubkey)) return false;
+    if (this.wotOnly[scope] && this.wot.size > 0 && !this.wot.has(pubkey)) return false;
+    return true;
+  };
+}
+
+function readLocalMutes(pubkey: string): string[] {
+  try {
+    const raw = localStorage.getItem(`${MUTE_KEY_PREFIX}${pubkey}`);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter((p) => typeof p === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
+function readToggle(scope: WotScope): boolean {
+  return localStorage.getItem(`${WOT_ONLY_PREFIX}${scope}`) === "1";
+}
+
+export const contentPolicy = new ContentPolicy();

--- a/src/utils/contentPolicy.ts
+++ b/src/utils/contentPolicy.ts
@@ -6,7 +6,10 @@
 // re-rendering. React layers subscribe via `version` (useSyncExternalStore)
 // and re-read whatever they need.
 
-export type WotScope = "notifs" | "comments" | "likes";
+export type WotScope = "notifsForeground" | "notifsBackground" | "comments" | "likes";
+
+export type NotifsScope = Extract<WotScope, "notifsForeground" | "notifsBackground">;
+export const NOTIFS_SCOPES: NotifsScope[] = ["notifsForeground", "notifsBackground"];
 
 // Durable caches: the device-local copy of our own (private) mute list gives
 // active filtering on launch before relays answer; the toggles are
@@ -25,7 +28,7 @@ type WotOnlyToggles = Record<WotScope, boolean>;
 class ContentPolicy {
   private muted = new Set<string>();
   private wot = new Set<string>();
-  private wotOnly: WotOnlyToggles = { notifs: false, comments: false, likes: false };
+  private wotOnly: WotOnlyToggles = { notifsForeground: false, notifsBackground: false, comments: false, likes: false };
   private listeners = new Set<() => void>();
   // Account the current muted set belongs to (guards cross-account writes).
   private account: string | null = null;
@@ -53,7 +56,8 @@ class ContentPolicy {
     this.account = pubkey;
     this.muted = new Set(readLocalMutes(pubkey));
     this.wotOnly = {
-      notifs: readToggle("notifs"),
+      notifsForeground: readToggle("notifsForeground"),
+      notifsBackground: readToggle("notifsBackground"),
       comments: readToggle("comments"),
       likes: readToggle("likes"),
     };
@@ -66,7 +70,7 @@ class ContentPolicy {
     this.account = null;
     this.muted = new Set();
     this.wot = new Set();
-    this.wotOnly = { notifs: false, comments: false, likes: false };
+    this.wotOnly = { notifsForeground: false, notifsBackground: false, comments: false, likes: false };
     this.emit();
   }
 
@@ -140,6 +144,23 @@ class ContentPolicy {
     if (this.wotOnly[scope] && this.wot.size > 0 && !this.wot.has(pubkey)) return false;
     return true;
   };
+
+  // ── notifications split-surface helpers ──────────────────────────────────
+  // The notifications surface is split into foreground (in-app list) and
+  // background (Android OS push). Gates just use the per-scope toggle; these
+  // helpers exist for call sites that talk about "notifications" generally.
+
+  /** True when either notifications toggle is on (for aggregate UI hints). */
+  anyNotifsWotOnly = (): boolean =>
+    this.wotOnly.notifsForeground || this.wotOnly.notifsBackground;
+
+  /** Ingestion gate for an in-app notification (foreground scope). */
+  passesForegroundNotif = (pubkey: string | undefined, ownPubkey?: string): boolean =>
+    this.passes(pubkey, "notifsForeground", ownPubkey);
+
+  /** Ingestion gate for an Android push notification (background scope). */
+  passesBackgroundNotif = (pubkey: string | undefined, ownPubkey?: string): boolean =>
+    this.passes(pubkey, "notifsBackground", ownPubkey);
 }
 
 function readLocalMutes(pubkey: string): string[] {

--- a/src/utils/contentPolicy.ts
+++ b/src/utils/contentPolicy.ts
@@ -77,7 +77,7 @@ class ContentPolicy {
   getMuted = (): string[] => Array.from(this.muted);
 
   /** Ingest (replace) the muted set — from the durable copy or a fresh
-   * kind-10005 decrypt. `persist` false when the caller will publish first. */
+   * kind-10000 decrypt. `persist` false when the caller will publish first. */
   setMuted(pubkeys: string[], persist = true) {
     this.muted = new Set(pubkeys);
     if (persist && this.account) {

--- a/src/utils/wotBloom.ts
+++ b/src/utils/wotBloom.ts
@@ -1,0 +1,118 @@
+// Bloom filter for crossing the web-of-trust set to the Android background
+// worker. At 2nd-degree scale the WoT union reaches 100k–300k+ pubkeys; a JSON
+// array in SharedPreferences (~6.5 bytes/pubkey) would balloon to multiple MB
+// and be re-parsed on every worker run. A bloom filter is ~2KB per 1k entries
+// and chunked base64 keeps the Preferences blob manageable.
+//
+// The math must match NotificationWorker.java EXACTLY (tests cover the other
+// side of the wire format). Spec, frozenwire format v1:
+//   k = 11 double hashes, m = bits (power of two), big-endian u32 slices of the
+//   RAW pubkey bytes: h1 = bytes[0..4], h2 = bytes[4..8], idx_i = (h1 + i*h2) mod m.
+// No cryptographic hash — both sides read the same 64 bits off the raw hex so
+// there is no library-parity risk.
+
+export const WOT_BLOOM_BITS_PER_ENTRY = 16;
+export const WOT_BLOOM_K = 11;
+
+export interface WotBloom {
+  /** Bit count m (power of two). */
+  bits: number;
+  /** Base64 of the packed bit array, big-endian byte order. */
+  data: string;
+}
+
+/** Big-endian u32 at rawBytes[off]. Returns 0 on short reads (hex-decode has
+ * already guaranteed byte length; this guards hypothetical short keys). */
+function u32be(bytes: Uint8Array, off: number): number {
+  if (off + 4 > bytes.length) return 0;
+  // >>> 0 to get an unsigned 32-bit value.
+  return (
+    ((bytes[off] << 24) |
+      (bytes[off + 1] << 16) |
+      (bytes[off + 2] << 8) |
+      bytes[off + 3]) >>>
+    0
+  );
+}
+
+/** MurmurHash3 32-bit finalizer. Must match Java-side fmix32 exactly. */
+function fmix32(h: number): number {
+  let x = h >>> 0;
+  x = Math.imul(x ^ (x >>> 16), 0x85ebca6b);
+  x = Math.imul(x ^ (x >>> 13), 0xc2b2ae35);
+  return (x ^ (x >>> 16)) >>> 0;
+}
+
+/**
+ * Build the bridge filter from a set of pubkeys. Returns null for empty/no
+ * input (caller bridges "gate not enforcable" state instead).
+ */
+export function buildWotBloom(pubkeys: Iterable<string>): WotBloom | null {
+  const list = Array.from(pubkeys).filter((pk) => typeof pk === "string" && pk.length > 0);
+  if (list.length === 0) return null;
+
+  // Round m up to a whole number of bytes. No power-of-two requirement — both
+  // sides use true modulo (idx % m), unlike mask-based bloom implementations.
+  const targetBits = list.length * WOT_BLOOM_BITS_PER_ENTRY;
+  const m = Math.max(1024, Math.ceil(targetBits / 8) * 8);
+
+  const bytes = new Uint8Array(m >>> 3); // m / 8
+  const scratch = new Uint8Array(32);
+
+  for (const pk of list) {
+    let valid = true;
+    let h1 = 0;
+    let h2 = 0;
+    try {
+      for (let i = 0; i < 32; i++) {
+        const byte = parseInt(pk.substr(i * 2, 2), 16);
+        if (Number.isNaN(byte)) {
+          valid = false;
+          break;
+        }
+        scratch[i] = byte;
+      }
+      if (!valid || pk.length !== 64) {
+        // Non-hex/partial keys silently excluded: the JS-side exact-check gate
+        // never consults the bloom, so a missed entry here is only a missed
+        // filter optimization, not a correctness break.
+        continue;
+      }
+      h1 = u32be(scratch, 0);
+      h2 = u32be(scratch, 4);
+      // h1/h2 are adjacent slices of the same key — weakly correlated, which
+      // measurably inflates the FP rate (~4× in testing). Run each through the
+      // MurmurHash3 32-bit finalizer to decorrelate. |1 keeps h2 nonzero so a
+      // key like 00000000_00000001… can't collapse all k probes to one bit.
+      h1 = fmix32(h1);
+      // |1 keeps h2 nonzero (a key can't collapse all k probes to one bit);
+      // >>> 0 restores unsigned semantics — Java side hashes into an unsigned
+      // long, and values congruent mod 2^32 are NOT congruent mod m.
+      h2 = (fmix32(h2) | 1) >>> 0;
+    } catch {
+      continue;
+    }
+    for (let i = 0; i < WOT_BLOOM_K; i++) {
+      // JS % keeps the dividend's sign: i*h2 exceeds 2^31 for large h2, making
+      // the raw sum negative. Normalize like Java's positive long modulo.
+      const idx = ((h1 + i * h2) % m + m) % m;
+      bytes[idx >>> 3] |= 1 << (idx & 7);
+    }
+    // h2 === 0 collapses all k probes to the same bit — harmless (still a
+    // valid single-bit membership) but flag it in debug if needed.
+  }
+
+  return { bits: m, data: bytesToBase64(bytes) };
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = "";
+  const CHUNK = 0x8000;
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    const chunk = bytes.subarray(i, i + CHUNK);
+    for (let j = 0; j < chunk.length; j++) {
+      binary += String.fromCharCode(chunk[j]);
+    }
+  }
+  return btoa(binary);
+}


### PR DESCRIPTION
Mute list (NIP-51 kind 10005, private-only):
- Muted pubkeys NIP-44-encrypted to self in .content; no public tags
- Durable device cache (pollerama:mutes:<pubkey>) for instant restore
- Mute/Unmute in note, comment, and poll kebab menus; managed in Moderation settings with npub display and per-entry unmute

Per-surface WoT-only toggles (notifications / comments / likes):
- Fetch-level: standing subscriptions add an authors filter when the WoT set is small enough (<= 400) so non-WoT events are never fetched
- Ingest-level: contentPolicy gates notification seeding/push and the comment/like map builders (likes only in shared byETag), covering large WoT sets and muted authors everywhere
- Toggle state kept in a renderer-independent singleton so stable callbacks (pushNotification, filter builders) read it stale-free

Android background worker:
- Bridge mute list + WoT gate via Capacitor Preferences
- WoT crosses as a bloom filter (k=11, MurmurHash3-fmix32 of raw pubkey u32 slices, byte-aligned m, ~16 bits/entry) instead of a JSON array: 100k pubkeys -> ~267KB vs multi-MB; JS/Java parity verified with 0 false negatives at n=1/10/400/100k, FP rate 0.051% at 100k
- Worker drops muted/non-WoT authors before dedup/persist; fail-open when the filter is unusable; in-app list always re-filters exactly

UI: three WoT-only switches + muted-users list in Moderation settings