### PR TITLE
   fix(deps): update websocket-driver to 0.7.5

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -12800,9 +12800,9 @@ webpack@^5.64.4:
     webpack-sources "^3.2.3"
 
 websocket-driver@>=0.5.1, websocket-driver@^0.7.4:
-  version "0.7.4"
-  resolved "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz"
-  integrity sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/websocket-driver/-/websocket-driver-0.7.5.tgz#569d22764ab21f2de20af0e74b411e8ae5a0fa46"
+  integrity sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==
   dependencies:
     http-parser-js ">=0.5.1"
     safe-buffer ">=5.1.0"


### PR DESCRIPTION
 Fixes #240

  - Updates `websocket-driver` from `0.7.4` to `0.7.5` in `yarn.lock`.
  - Resolves CVE-2026-54466 in the Yarn dependency tree.
  - Regenerates the existing transitive lock entry without adding a direct dependency or resolution.
  - Verified with a frozen Yarn install, dependency-tree checks, tests, and a production build.
  - `package-lock.json` synchronization remains out of scope.
 